### PR TITLE
fix session release

### DIFF
--- a/session.go
+++ b/session.go
@@ -70,6 +70,10 @@ func (session *Session) reConnect() error {
 
 // Logout and release connetion hold by session
 func (session *Session) Release() {
+	if session == nil {
+		session.log.Warn("Session is nil, no need to release")
+		return
+	}
 	if session.connection == nil {
 		session.log.Warn("Session has been released")
 		return


### PR DESCRIPTION
ConnectionPool.GetSession() may return a nil pointer, so should check if session is nil when Release()