### PR TITLE
unify the string form of vertex and edge

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
           pushd tmp
           git clone -b v2-preview https://github.com/vesoft-inc/nebula-docker-compose.git
           pushd nebula-docker-compose/
-          sed -i '0,/\- 3699/s/\- 3699/\- "3710:3699"/' docker-compose.yaml
+          sed -i '0,/\- 3699/s/\- 3699/\- "3700:3699"/' docker-compose.yaml
           sed -i '0,/\- 3699/s/\- 3699/\- "3701:3699"/' docker-compose.yaml
           docker-compose up -d
           sleep 10

--- a/client_test.go
+++ b/client_test.go
@@ -32,11 +32,11 @@ var poolAddress = []HostAddress{
 	},
 	HostAddress{
 		Host: "127.0.0.1",
-		Port: 3701,
+		Port: 3700,
 	},
 	HostAddress{
 		Host: "127.0.0.1",
-		Port: 3710,
+		Port: 3701,
 	},
 }
 
@@ -356,10 +356,10 @@ func TestReconnect(t *testing.T) {
 	for i := 0; i < timeoutConfig.MaxConnPoolSize; i++ {
 		time.Sleep(200 * time.Millisecond)
 		if i == 3 {
-			stopContainer(t, "nebula-docker-compose_graphd_1")
+			stopContainer(t, "nebula-docker-compose_graphd0_1")
 		}
 		if i == 7 {
-			stopContainer(t, "nebula-docker-compose_graphd2_1")
+			stopContainer(t, "nebula-docker-compose_graphd1_1")
 		}
 		_, err := sessionList[0].Execute("SHOW HOSTS;")
 		fmt.Println("Sending query...")
@@ -379,8 +379,8 @@ func TestReconnect(t *testing.T) {
 	// This assertion will pass only when reconnection happens
 	assert.Equal(t, ErrorCode_E_SESSION_INVALID, resp.GetErrorCode(), "Expected error should be E_SESSION_INVALID")
 
-	startContainer(t, "nebula-docker-compose_graphd_1")
-	startContainer(t, "nebula-docker-compose_graphd2_1")
+	startContainer(t, "nebula-docker-compose_graphd0_1")
+	startContainer(t, "nebula-docker-compose_graphd1_1")
 
 	for i := 0; i < len(sessionList); i++ {
 		sessionList[i].Release()

--- a/client_test.go
+++ b/client_test.go
@@ -356,7 +356,7 @@ func TestReconnect(t *testing.T) {
 	for i := 0; i < timeoutConfig.MaxConnPoolSize; i++ {
 		time.Sleep(200 * time.Millisecond)
 		if i == 3 {
-			stopContainer(t, "nebula-docker-compose_graphd0_1")
+			stopContainer(t, "nebula-docker-compose_graphd_1")
 		}
 		if i == 7 {
 			stopContainer(t, "nebula-docker-compose_graphd1_1")
@@ -379,7 +379,7 @@ func TestReconnect(t *testing.T) {
 	// This assertion will pass only when reconnection happens
 	assert.Equal(t, ErrorCode_E_SESSION_INVALID, resp.GetErrorCode(), "Expected error should be E_SESSION_INVALID")
 
-	startContainer(t, "nebula-docker-compose_graphd0_1")
+	startContainer(t, "nebula-docker-compose_graphd_1")
 	startContainer(t, "nebula-docker-compose_graphd1_1")
 
 	for i := 0; i < len(sessionList); i++ {

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/facebook/fbthrift v0.0.0-20190922225929-2f9839604e25 h1:dezRDs9oGYxeavyvcNg/Js+dK6kIvfzERoJ7K8Xkv14=
 github.com/facebook/fbthrift v0.0.0-20190922225929-2f9839604e25/go.mod h1:2tncLx5rmw69e5kMBv/yJneERbzrr1yr5fdlnTbu8lU=
+github.com/facebook/fbthrift v0.31.0 h1:vVZbmPbaHuC58HCKgsYgj8GKe89nC4dPmFI/8kKNXDE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/result_set.go
+++ b/result_set.go
@@ -479,6 +479,9 @@ func (node Node) string() string {
 		keyList = nil
 		kvStr = nil
 	}
+	if len(tagStr) == 0 { // No tag
+		return fmt.Sprintf("(\"%s\")", vid)
+	}
 	return fmt.Sprintf("(\"%s\" :%s)", vid, strings.Join(tagStr, " :"))
 }
 
@@ -538,7 +541,7 @@ func (relationship Relationship) Values() []*ValueWrapper {
 	return values
 }
 
-// Relationship format: (src)-[:edge@ranking{props}]->(dst)
+// Relationship format: [:edge src->dst @ranking {props}]
 func (relationship Relationship) string() string {
 	edge := relationship.edge
 	var keyList []string
@@ -551,9 +554,12 @@ func (relationship Relationship) string() string {
 		kvTemp := fmt.Sprintf("%s: %s", k, ValueWrapper{edge.Props[k]}.String())
 		kvStr = append(kvStr, kvTemp)
 	}
-
-	return fmt.Sprintf(`("%s")-[:%s@%d{%s}]->("%s")`,
-		string(edge.Src), string(edge.Name), edge.Ranking, fmt.Sprintf("%s", strings.Join(kvStr, ", ")), string(edge.Dst))
+	if len(kvStr) == 0 {
+		return fmt.Sprintf(`[:%s "%s"->"%s" @%d]`,
+			string(edge.Name), string(edge.Src), string(edge.Dst), edge.Ranking)
+	}
+	return fmt.Sprintf(`[:%s "%s"->"%s" @%d {%s}]`,
+		string(edge.Name), string(edge.Src), string(edge.Dst), edge.Ranking, fmt.Sprintf("%s", strings.Join(kvStr, ", ")))
 }
 
 func (r1 Relationship) IsEqualTo(r2 *Relationship) bool {

--- a/value_wrapper.go
+++ b/value_wrapper.go
@@ -279,7 +279,7 @@ func (valWarp ValueWrapper) String() string {
 		vertex := value.GetVVal()
 		node, _ := genNode(vertex)
 		return node.string()
-	} else if value.IsSetEVal() { // Edge format: (src)-[:edge@ranking{props}]->(dst)
+	} else if value.IsSetEVal() { // Edge format: [:edge src->dst @ranking {props}]
 		edge := value.GetEVal()
 		relationship, _ := genRelationship(edge)
 		return relationship.string()


### PR DESCRIPTION
1. Update string format of vertex/edge
    The edge is now represented in form: ``` [:edge src->dst @ranking {props}]```

2. Add tests for vertex without tag and edge without property