### PR TITLE
Do not escape a string prop in string()

### DIFF
--- a/value_wrapper.go
+++ b/value_wrapper.go
@@ -263,7 +263,7 @@ func (valWarp ValueWrapper) String() string {
 		}
 		return fStr
 	} else if value.IsSetSVal() {
-		return `"` + string(value.GetSVal()) + `"`
+		return fmt.Sprintf("%#v", string(value.GetSVal()))
 	} else if value.IsSetDVal() { // Date yyyy-mm-dd
 		date := value.GetDVal()
 		return fmt.Sprintf("%d-%02d-%02d", date.Year, date.Month, date.Day)


### PR DESCRIPTION
Insert a string prop with escape char:
```
(root@nebula) [nba]> insert vertex player(name, age) values "101":("ji\ne", 18)
Execution succeeded (time spent 1939/2297 us)
```

before:
```
(root@nebula) [nba]> FETCH PROP ON player "101"
+-----------------------------------------+
| vertices_                               |
+-----------------------------------------+
| ("101" :player{age: 18, name: "ji
e"}) |
+-----------------------------------------+
Got 1 rows (time spent 1714/2017 us)
```

after:
```
(root@nebula) [nba]> FETCH PROP ON player "101"
+-----------------------------------------+
| vertices_                               |
+-----------------------------------------+
| ("101" :player{age: 18, name: "ji\ne"}) |
+-----------------------------------------+
Got 1 rows (time spent 1714/2017 us)
```
