### PR TITLE
Add stmt wrapper

### DIFF
--- a/stmt_wrapper.go
+++ b/stmt_wrapper.go
@@ -1,0 +1,448 @@
+package nebula_go
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// StmtWrapper create stmt with a template and params.
+// StmtWrapper use?{} as the parameter tag, Similarly, support Date, Time, DateTime, Timestamp, List, Map in ngql,
+func StmtWrapper(stmt string, params map[string]interface{}) (string, error) {
+	sb := strings.Builder{}
+
+	for i := 0; i < len(stmt); i++ {
+
+		if i >= len(stmt)-3 {
+			sb.WriteString(stmt[i:])
+			break
+		}
+
+		if stmt[i] == '?' && stmt[i+1] == '{' {
+			var j = i
+			for ; i < len(stmt); j++ {
+				if stmt[j] == '}' {
+					break
+				}
+			}
+			k := stmt[i+2 : j]
+
+			v, has := params[k]
+			if !has {
+				return "", fmt.Errorf("param %s not found", k)
+			}
+			val, err := getValue(v)
+			if err != nil {
+				return "", err
+			}
+
+			sb.WriteString(val)
+			i = j
+		} else {
+			sb.WriteByte(stmt[i])
+		}
+	}
+
+	return sb.String(), nil
+}
+
+func getValue(v interface{}) (string, error) {
+	if f, ok := v.(queryFormatter); ok {
+		return f.QueryFormat(), nil
+	}
+	return getValueReflect(v)
+}
+
+func getValueReflect(v interface{}) (string, error) {
+	vt := reflect.ValueOf(v)
+
+	switch vt.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(vt.Bool()), nil
+	case reflect.Float32, reflect.Float64:
+		return strconv.FormatFloat(vt.Float(), 'f', 10, 64), nil
+	case reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int:
+		return strconv.FormatInt(vt.Int(), 10), nil
+	case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
+		u := vt.Uint()
+		if u > math.MaxInt64 {
+			return "", fmt.Errorf("not supported beyond int64")
+		}
+		return strconv.FormatUint(u, 10), nil
+	case reflect.String:
+		return "\"" + vt.String() + "\"", nil
+	case reflect.Slice:
+		return sliceFormat(v)
+	case reflect.Map:
+		return mapFormat(v)
+
+	}
+	return "", fmt.Errorf("param type not support ")
+}
+
+func sliceFormat(x interface{}) (string, error) {
+	//Optimal performance is greater than reflection
+	sb := strings.Builder{}
+
+	sb.WriteByte('[')
+
+	switch v := x.(type) {
+	case []interface{}:
+		for i := range v {
+			val, err := getValue(v[i])
+			if err != nil {
+				return "", err
+			}
+			sb.WriteString(val)
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []string:
+		for i := range v {
+			sb.WriteString("\"" + v[i] + "\"")
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []int64:
+		for i := range v {
+			sb.WriteString(strconv.FormatInt(v[i], 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []uint64:
+		for i := range v {
+			if v[i] > math.MaxInt64 {
+				return "", fmt.Errorf("not supported beyond int64")
+			}
+			sb.WriteString(strconv.FormatUint(v[i], 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []int:
+		for i := range v {
+			sb.WriteString(strconv.Itoa(v[i]))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []uint8:
+		for i := range v {
+			sb.WriteString(strconv.FormatUint(uint64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []int8:
+		for i := range v {
+			sb.WriteString(strconv.FormatInt(int64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+
+	case []uint16:
+		for i := range v {
+			sb.WriteString(strconv.FormatUint(uint64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []int16:
+		for i := range v {
+			sb.WriteString(strconv.FormatInt(int64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []uint32:
+		for i := range v {
+			sb.WriteString(strconv.FormatUint(uint64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []int32:
+		for i := range v {
+			sb.WriteString(strconv.FormatInt(int64(v[i]), 10))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []float64:
+		for i := range v {
+			sb.WriteString(strconv.FormatFloat(v[i], 'f', 10, 64))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	case []float32:
+		for i := range v {
+			sb.WriteString(strconv.FormatFloat(float64(v[i]), 'f', 10, 64))
+			if i != len(v)-1 {
+				sb.WriteByte(',')
+			}
+		}
+	default:
+		return "", fmt.Errorf("param type not support ")
+	}
+
+	sb.WriteByte(']')
+	return sb.String(), nil
+}
+
+func mapFormat(x interface{}) (string, error) {
+	//Optimal performance is greater than reflection
+	sb := strings.Builder{}
+	sb.WriteByte('{')
+
+	switch m := x.(type) {
+	case map[string]interface{}:
+		cnt := 0
+		for k, v := range m {
+			val, err := getValue(v)
+			if err != nil {
+				return "", err
+			}
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(val)
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+
+	case map[string]string:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString("\"" + v + "\"")
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]float64:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatFloat(v, 'f', 10, 64))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]float32:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatFloat(float64(v), 'f', 10, 64))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]int:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.Itoa(v))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]int8:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatInt(int64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]uint8:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatUint(uint64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]int16:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatInt(int64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]uint16:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatUint(uint64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]int32:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatInt(int64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]uint32:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatUint(uint64(v), 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]int64:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatInt(v, 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]uint64:
+		cnt := 1
+		for k, v := range m {
+			if v > math.MaxInt64 {
+				return "", fmt.Errorf("not supported beyond int64")
+			}
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatUint(v, 10))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	case map[string]bool:
+		cnt := 1
+		for k, v := range m {
+			cnt += 1
+			sb.WriteString(k)
+			sb.WriteByte(':')
+			sb.WriteString(strconv.FormatBool(v))
+			if cnt == len(m) {
+				sb.WriteByte(',')
+			}
+		}
+	default:
+		return "", fmt.Errorf("param type not support ")
+	}
+	sb.WriteByte('}')
+	return sb.String(), nil
+}
+
+type queryFormatter interface {
+	QueryFormat() string
+}
+
+const (
+	dateFormat     = "2006-01-02"
+	timeFormat     = "15:04:05.000"
+	datetimeFormat = "2006-01-02T15:04:05"
+)
+
+type Date struct {
+	time.Time
+}
+
+func (t Date) QueryFormat() string {
+	return "date(\"" + t.Format(dateFormat) + "\")"
+}
+
+func DateOf(t time.Time) Date {
+	return Date{Time: t}
+}
+
+func DateOfNumber(y, m, d int) Date {
+	return Date{time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.Local)}
+}
+
+type Time struct {
+	time.Time
+}
+
+func (t Time) QueryFormat() string {
+	return "time(\"" + t.Format(timeFormat) + "\")"
+}
+
+func TimeOfNumber(h, m, s int) Time {
+	return Time{time.Date(0, 0, 0, h, m, s, 0, time.Local)}
+}
+
+func TimeOf(t time.Time) Time {
+	return Time{Time: t}
+}
+
+type DateTime struct {
+	time.Time
+}
+
+func (t DateTime) QueryFormat() string {
+	return "datetime(\"" + t.Format(datetimeFormat) + "\")"
+}
+
+func DateTimeOf(t time.Time) DateTime {
+	return DateTime{Time: t}
+}
+
+type Timestamp struct {
+	data int64
+}
+
+func (t Timestamp) QueryFormat() string {
+	return strconv.FormatInt(t.data, 10)
+}
+
+func TimestampOfNumber(t int64) Timestamp {
+	return Timestamp{data: t}
+}
+func TimestampOf(t time.Time) Timestamp {
+	return Timestamp{data: t.Unix()}
+}
+
+type NULL struct{}
+
+func (n NULL) QueryFormat() string {
+	return "null"
+}

--- a/stmt_wrapper_test.go
+++ b/stmt_wrapper_test.go
@@ -1,0 +1,195 @@
+package nebula_go
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestStmtWrapper(t *testing.T) {
+	time.Local = time.UTC
+	type args struct {
+		stmt   string
+		params map[string]interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "simple insert vertex",
+			args: args{
+				stmt: "INSERT VERTEX t2 (name, age) VALUES ?{vid}:(?{name}, ?{age});",
+				params: map[string]interface{}{
+					"vid":  "vid_1",
+					"name": "foo",
+					"age":  123,
+				},
+			},
+			want:    `INSERT VERTEX t2 (name, age) VALUES "vid_1":("foo", 123);`,
+			wantErr: false,
+		},
+		{
+			name: "simple insert edge",
+			args: args{
+				stmt: "INSERT EDGE e2 (name, age) VALUES ?{from}->?{to}@1:(?{name}, ?{age});",
+				params: map[string]interface{}{
+					"from": "vid_1",
+					"to":   "vid_2",
+					"name": "foo",
+					"age":  123,
+				},
+			},
+			want: `INSERT EDGE e2 (name, age) VALUES "vid_1"->"vid_2"@1:("foo", 123);`,
+
+			wantErr: false,
+		},
+		{
+			name: "simple update edge",
+			args: args{
+				stmt: `UPDATE EDGE on serve ?{from} -> ?{to}@0
+        SET start_year = start_year + 1
+        WHEN end_year > ?{year}
+        YIELD start_year, end_year;`,
+				params: map[string]interface{}{
+					"from": "vid_1",
+					"to":   "vid_2",
+					"year": 2001,
+				},
+			},
+			want: `UPDATE EDGE on serve "vid_1" -> "vid_2"@0
+        SET start_year = start_year + 1
+        WHEN end_year > 2001
+        YIELD start_year, end_year;`,
+
+			wantErr: false,
+		},
+
+		{
+			name: "simple match",
+			args: args{
+				stmt: "MATCH p=(v:player{name:?{name}})-[e:follow*1..3]->(v2) RETURN v2 AS Friends",
+				params: map[string]interface{}{
+					"name": "Tim Duncan",
+				},
+			},
+			want:    `MATCH p=(v:player{name:"Tim Duncan"})-[e:follow*1..3]->(v2) RETURN v2 AS Friends`,
+			wantErr: false,
+		},
+		{
+			name: "time",
+			args: args{
+				stmt: `INSERT VERTEX date1(p1, p2, p3, p4)
+				VALUES "test1":(?{date}, ?{time}, ?{datetime}, ?{timestamp});`,
+				params: map[string]interface{}{
+					"date":      DateOfNumber(2021, 3, 17),
+					"time":      TimeOfNumber(17, 53, 59),
+					"datetime":  DateTimeOf(time.Date(2021, 3, 17, 17, 53, 59, 0, time.Local)),
+					"timestamp": TimestampOf(time.Date(2021, 3, 17, 17, 53, 59, 0, time.Local)),
+				},
+			},
+			want: `INSERT VERTEX date1(p1, p2, p3, p4)
+				VALUES "test1":(date("2021-03-17"), time("17:53:59.000"), datetime("2021-03-17T17:53:59"), 1616003639);`,
+			wantErr: false,
+		},
+		{
+			name: "match with list string",
+			args: args{
+				stmt: `MATCH (v:player { name: ?{name} })--(v2)
+        WHERE id(v2) IN ?{list} RETURN v2;`,
+				params: map[string]interface{}{
+					"name": "Tim Duncan",
+					"list": []string{"player101", "player102"},
+				},
+			},
+			want: `MATCH (v:player { name: "Tim Duncan" })--(v2)
+        WHERE id(v2) IN ["player101","player102"] RETURN v2;`,
+			wantErr: false,
+		},
+		{
+			name: "match with list int",
+			args: args{
+				stmt: `MATCH (v:player { name: ?{name} })--(v2)
+        WHERE id(v2) IN ?{list} RETURN v2;`,
+				params: map[string]interface{}{
+					"name": "Tim Duncan",
+					"list": []int32{123, 456},
+				},
+			},
+			want: `MATCH (v:player { name: "Tim Duncan" })--(v2)
+        WHERE id(v2) IN [123,456] RETURN v2;`,
+			wantErr: false,
+		},
+
+		{
+			name: "map list",
+			args: args{
+				stmt: `YIELD {key: 'Value', listKey: ?{m}}`,
+				params: map[string]interface{}{
+					"m": []interface{}{map[string]string{"inner": "Map1"}, map[string]int{"inner": 123}},
+				},
+			},
+			want:    `YIELD {key: 'Value', listKey: [{inner:"Map1"},{inner:123}]}`,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := StmtWrapper(tt.args.stmt, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("StmtWrapper() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("StmtWrapper() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ExampleStmtWrapper() {
+
+	stmt, err := StmtWrapper("INSERT VERTEX t2 (name, age) VALUES ?{vid}:(?{name}, ?{age});", map[string]interface{}{
+		"vid":  "vid_1",
+		"name": "foo",
+		"age":  123,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("insert stmt:", stmt)
+
+	stmt, err = StmtWrapper("INSERT EDGE e2 (name, age) VALUES ?{from}->?{to}@1:(?{name}, ?{age});",
+		map[string]interface{}{
+			"from": "vid_1",
+			"to":   "vid_2",
+			"name": "foo",
+			"age":  123,
+		})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("insert edge stmt:", stmt)
+
+	stmt, err = StmtWrapper("MATCH (v:player { born: ?{born} })--(v2) WHERE id(v2) IN ?{list} RETURN v2;",
+		map[string]interface{}{
+			"name": DateOfNumber(2000, 10, 1),
+			"list": 123,
+		})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("match stmt:", stmt)
+
+	stmt, err = StmtWrapper("YIELD {listMap: ?{map}, listKey: ?{list}};",
+		map[string]interface{}{
+			"map":  map[string]string{"foo": "bar"},
+			"list": []string{"foo", "bar"},
+		})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("map list stmt:", stmt)
+}


### PR DESCRIPTION
#111 
Unlike this issues, this implementation uses ? {} as a parameter template, because {} conflicts with match.