### PR TITLE
Release the transport when version verification fail

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -76,6 +76,7 @@ func (cn *connection) verifyClientVersion() error {
 	req := graph.NewVerifyClientVersionReq()
 	resp, err := cn.graph.VerifyClientVersion(req)
 	if err != nil {
+		cn.close()
 		return fmt.Errorf("failed to verify client version: %s", err.Error())
 	}
 	if resp.GetErrorCode() != nebula.ErrorCode_SUCCEEDED {


### PR DESCRIPTION
As title.
Version check failure may cause Zombie connections.