### PR TITLE
Escape graphviz meta char.

### DIFF
--- a/result_set.go
+++ b/result_set.go
@@ -1072,6 +1072,10 @@ func graphvizString(s string) string {
 	s = strings.Replace(s, "\"", "\\\"", -1)
 	s = strings.Replace(s, "[", "\\[", -1)
 	s = strings.Replace(s, "]", "\\]", -1)
+	s = strings.Replace(s, "(", "\\(", -1)
+	s = strings.Replace(s, ")", "\\)", -1)
+	s = strings.Replace(s, "<", "\\<", -1)
+	s = strings.Replace(s, ">", "\\>", -1)
 	return s
 }
 


### PR DESCRIPTION
This happens in `explain format = 'dot' match (v) return (v)-[:like]->()`, its column name is `(v)-[:like]->()`