### PR TITLE
[bug] Remove invalid connection from the idle queue when request new connection

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -151,7 +151,7 @@ func (pool *ConnectionPool) getIdleConn() (*connection, error) {
 				newConn = ele.Value.(*connection)
 				newEle = ele
 				break
-			}else{
+			} else {
 				tmpNextEle = ele.Next()
 				pool.idleConnectionQueue.Remove(ele)
 			}

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -144,12 +144,16 @@ func (pool *ConnectionPool) getIdleConn() (*connection, error) {
 	if pool.idleConnectionQueue.Len() > 0 {
 		var newConn *connection = nil
 		var newEle *list.Element = nil
-		for ele := pool.idleConnectionQueue.Front(); ele != nil; ele = ele.Next() {
+		var tmpNextEle *list.Element = nil
+		for ele := pool.idleConnectionQueue.Front(); ele != nil; ele = tmpNextEle {
 			// Check if connection is valid
 			if res := ele.Value.(*connection).ping(); res {
 				newConn = ele.Value.(*connection)
 				newEle = ele
 				break
+			}else{
+				tmpNextEle = ele.Next()
+				pool.idleConnectionQueue.Remove(ele)
 			}
 		}
 		if newConn == nil {


### PR DESCRIPTION
[bug] 移除无效连接 ，防止由于无效连接导致 连接总数超出MaxConnPoolSize，导致创建session失败

Fail to create a new session from connection pool, username: xxx, password: xxxx, failed to get connection: No valid connection in the idle queue and connection number has reached the pool capacity