### PR TITLE
add session manager

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/vesoft-inc/nebula-go/v3
 go 1.13
 
 require (
+	github.com/bits-and-blooms/bitset v1.3.0
 	github.com/facebook/fbthrift v0.31.1-0.20211129061412-801ed7f9f295
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bits-and-blooms/bitset v1.3.0 h1:h7mv5q31cthBTd7V4kLAZaIThj1e8vPGcSqpPue9KVI=
+github.com/bits-and-blooms/bitset v1.3.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/facebook/fbthrift v0.31.1-0.20211129061412-801ed7f9f295 h1:ZA+qQ3d2In0RNzVpk+D/nq1sjDSv+s1Wy2zrAPQAmsg=

--- a/session_manager.go
+++ b/session_manager.go
@@ -1,0 +1,157 @@
+package nebula_go
+
+import (
+	"crypto/tls"
+	"fmt"
+	"github.com/bits-and-blooms/bitset"
+	"sync"
+)
+
+type ManagerConfig struct {
+	username   string
+	password   string
+	spaceName  string
+	addresses  []HostAddress
+	poolConfig PoolConfig
+	sslConfig  *tls.Config
+}
+
+type SessionManager struct {
+	config         ManagerConfig
+	mutex          sync.Mutex
+	isClose        bool
+	log            Logger
+	pool           *ConnectionPool
+	idleBitSet     *bitset.BitSet
+	idleSessionMap map[uint]*SessionWrapper
+	sessionMap     map[int64]*SessionWrapper
+}
+
+func NewSessionManager(config ManagerConfig, log Logger) (*SessionManager, error) {
+	if len(config.spaceName) == 0 {
+		return nil, fmt.Errorf("fail to create session manager: space name can not be empty")
+	}
+	config.poolConfig.validateConf(log)
+
+	manager := &SessionManager{
+		config: config,
+		log:    log,
+	}
+	err := manager.initManager()
+	if err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+func (m *SessionManager) initManager() error {
+
+	var pool *ConnectionPool
+	var err error
+	if m.config.sslConfig != nil {
+		pool, err = NewConnectionPool(m.config.addresses, m.config.poolConfig, m.log)
+	} else {
+		pool, err = NewSslConnectionPool(m.config.addresses, m.config.poolConfig, m.config.sslConfig, m.log)
+	}
+
+	if err != nil {
+		return err
+	}
+	m.pool = pool
+
+	// idleBitSet: bitset contains [config.poolConfig.MaxConnPoolSize] bits
+	// idleBitSet: [1, 0, 1, .... 0], set value of position-i to 1 means there is an idle wrapper-session available in idleSessionMap
+	m.idleBitSet = bitset.New(uint(m.config.poolConfig.MaxConnPoolSize))
+
+	// sessionMap : <index of idleBitSet: *SessionWrapper>
+	m.idleSessionMap = make(map[uint]*SessionWrapper)
+
+	// all session get from manager, <sessionId, *SessionWrapper>
+	m.sessionMap = make(map[int64]*SessionWrapper)
+
+	return nil
+}
+
+// GetSession get a wrapper session from sessionManager
+func (m *SessionManager) GetSession() (*SessionWrapper, error) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.isClose {
+		return nil, fmt.Errorf("fail to get new seesion, session manager has closed")
+	}
+
+	// if there are any available session
+	if m.idleBitSet.Count() != 0 {
+		index, ok := m.idleBitSet.NextSet(0)
+		if ok {
+			m.idleBitSet.Clear(index)
+			session := m.idleSessionMap[index]
+			delete(m.idleSessionMap, index)
+			return session, nil
+		}
+	}
+
+	// create new Session from pool
+	session, err := m.pool.GetSession(m.config.username, m.config.password)
+	if err != nil {
+		return nil, err
+	}
+
+	// change space
+	result, err := session.Execute("USE " + m.config.spaceName)
+	if err != nil {
+		return nil, err
+	}
+	if !result.IsSucceed() {
+		return nil, fmt.Errorf("fail to get new seesion, change space error: %s", err.Error())
+	}
+
+	sessionWrapper := &SessionWrapper{session: session, sessionManager: m, sessionId: session.GetSessionID()}
+	m.sessionMap[session.GetSessionID()] = sessionWrapper
+	return sessionWrapper, nil
+}
+
+// ReleaseSession release wrapper session to sessionManager
+func (m *SessionManager) ReleaseSession(sessionWrapper *SessionWrapper) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	// do nothing
+	if sessionWrapper == nil || sessionWrapper.isRelease || m.isClose {
+		return
+	}
+
+	// session is not created by manager, just return to pool
+	if _, ok := m.sessionMap[sessionWrapper.session.GetSessionID()]; !ok {
+		sessionWrapper.session.Release()
+		return
+	}
+
+	// acquire position from idleBitSet
+	setIndex, ok := m.idleBitSet.NextClear(0)
+	if !ok {
+		sessionWrapper.session.Release()
+	} else {
+		m.idleBitSet.Set(setIndex)
+		newWrapper := &SessionWrapper{session: sessionWrapper.session, sessionManager: m, sessionId: sessionWrapper.sessionId}
+		m.idleSessionMap[setIndex] = newWrapper
+	}
+	sessionWrapper.isRelease = true
+	sessionWrapper.session = nil
+	sessionWrapper.sessionManager = nil
+}
+
+// Close mark all wrapper session to release status and close connection pool
+func (m *SessionManager) Close() {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	for _, v := range m.sessionMap {
+		v.isRelease = true
+	}
+	m.sessionMap = nil
+	m.idleSessionMap = nil
+	m.pool.Close()
+	m.isClose = true
+}

--- a/session_manager.go
+++ b/session_manager.go
@@ -104,7 +104,7 @@ func (m *SessionManager) GetSession() (*SessionWrapper, error) {
 		return nil, err
 	}
 	if !result.IsSucceed() {
-		return nil, fmt.Errorf("fail to get new seesion, change space error: %s", err.Error())
+		return nil, fmt.Errorf("fail to get new seesion, change space error")
 	}
 
 	sessionWrapper := &SessionWrapper{session: session, sessionManager: m, sessionId: session.GetSessionID()}

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -1,0 +1,110 @@
+package nebula_go
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func GetManagerConfig(minPoolSize int, maxPoolSize int) ManagerConfig {
+	return ManagerConfig{
+		username: "root",
+		password: "",
+		addresses: []HostAddress{
+			{
+				Host: "127.0.0.1",
+				Port: 9669,
+			},
+		},
+		// schema : https://docs.nebula-graph.com.cn/3.1.0/2.quick-start/4.nebula-graph-crud/
+		spaceName:  "basketballplayer",
+		poolConfig: GetPoolConfig(minPoolSize, maxPoolSize),
+	}
+}
+
+func GetPoolConfig(minPoolSize int, maxPoolSize int) PoolConfig {
+	return PoolConfig{
+		MinConnPoolSize: minPoolSize,
+		MaxConnPoolSize: maxPoolSize,
+		IdleTime:        0,
+	}
+}
+
+func TestSessionManager(t *testing.T) {
+	manager, err := NewSessionManager(GetManagerConfig(1, 2), DefaultLogger{})
+	if err != nil {
+		t.Fail()
+		return
+	}
+	defer manager.Close()
+	session, err := manager.GetSession()
+	if err != nil {
+		t.Fail()
+		return
+	}
+	// schema : https://docs.nebula-graph.com.cn/3.1.0/2.quick-start/4.nebula-graph-crud/
+	result, err := session.Execute("GO FROM \"player101\" OVER follow YIELD id($$);")
+	if err != nil || !result.IsSucceed() {
+		t.Fail()
+		return
+	}
+	assert.True(t, len(result.GetRows()) != 0)
+}
+
+// go test -bench=SessionManager -benchtime=10000x -run=^a
+func BenchmarkSessionManager(b *testing.B) {
+	manager, err := NewSessionManager(GetManagerConfig(10, 20), DefaultLogger{})
+	if err != nil {
+		b.Fail()
+		return
+	}
+	defer manager.Close()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			session, err := manager.GetSession()
+			if err != nil {
+				fmt.Sprintf("get session err: %v", err)
+				panic(err)
+			}
+
+			result, err := session.Execute("GO FROM \"player101\" OVER follow YIELD id($$)")
+			if err != nil || !result.IsSucceed() {
+				fmt.Sprintf("execute statment err: %v", err)
+				session.Release()
+				panic(err)
+			}
+			session.Release()
+		}
+	})
+}
+
+// go test -bench=SessionPool -benchtime=10000x -run=^a
+func BenchmarkSessionPool(b *testing.B) {
+	config := GetManagerConfig(10, 20)
+	pool, err := NewConnectionPool(config.addresses, config.poolConfig, DefaultLogger{})
+	if err != nil {
+		b.Fail()
+		return
+	}
+	defer pool.Close()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			session, err := pool.GetSession(config.username, config.password)
+			if err != nil {
+				fmt.Sprintf("get session err: %v", err)
+				panic(err)
+			}
+
+			result, err := session.Execute("USE basketballplayer;GO FROM \"player101\" OVER follow YIELD id($$);")
+			if err != nil || !result.IsSucceed() {
+				fmt.Sprintf("execute statment err: %v", err)
+				session.Release()
+				panic(err)
+			}
+			session.Release()
+		}
+	})
+}

--- a/session_manager_test.go
+++ b/session_manager_test.go
@@ -139,13 +139,13 @@ func InitData() error {
 		"CREATE TAG IF NOT EXISTS player(name string, age int);" +
 		"CREATE EDGE IF NOT EXISTS follow(degree int);"
 
-	_, err = tryToExecute(session, schema)
+	_, err = Execute(session, schema)
 	if err != nil {
 		return fmt.Errorf("test session manager, init data schema fail, %s", err.Error())
 	}
 
 	dataStatement := "INSERT VERTEX player(name, age) VALUES \"player101\":(\"Tony Parker\", 36), \"player100\":(\"Tim Duncan\", 42);"
-	_, err = tryToExecute(session, dataStatement)
+	_, err = Execute(session, dataStatement)
 	if err != nil {
 		return fmt.Errorf("test session manager, init data fail, %s", err.Error())
 	}
@@ -153,7 +153,7 @@ func InitData() error {
 	time.Sleep(2 * time.Second)
 
 	dataStatement = "INSERT EDGE follow(degree) VALUES \"player101\" -> \"player100\":(95);"
-	_, err = tryToExecute(session, dataStatement)
+	_, err = Execute(session, dataStatement)
 	if err != nil {
 		return fmt.Errorf("test session manager, init data fail, %s", err.Error())
 	}
@@ -166,7 +166,7 @@ func skipBenchmark(b *testing.B) {
 	}
 }
 
-func tryToExecute(session *Session, query string) (resp *ResultSet, err error) {
+func Execute(session *Session, query string) (resp *ResultSet, err error) {
 	for i := 3; i > 0; i-- {
 		resp, err = session.Execute(query)
 		if err == nil && resp.IsSucceed() {

--- a/session_wrapper.go
+++ b/session_wrapper.go
@@ -1,0 +1,51 @@
+package nebula_go
+
+import "fmt"
+
+type SessionWrapper struct {
+	session        *Session
+	sessionManager *SessionManager
+	sessionId      int64
+	isRelease      bool
+}
+
+func (w *SessionWrapper) GetSessionID() (int64, error) {
+	if w.isRelease {
+		return -1, fmt.Errorf("can not get session id of a released session wrapper")
+	}
+	return w.session.sessionID, nil
+}
+
+func (w *SessionWrapper) Release() {
+	if !w.isRelease {
+		w.sessionManager.ReleaseSession(w)
+	}
+}
+
+func (w *SessionWrapper) ExecuteWithParameter(stmt string, params map[string]interface{}) (*ResultSet, error) {
+	if w.isRelease {
+		return nil, fmt.Errorf("can not execute statement by a released session wrapper")
+	}
+	return w.session.ExecuteWithParameter(stmt, params)
+}
+
+func (w *SessionWrapper) Execute(stmt string) (*ResultSet, error) {
+	if w.isRelease {
+		return nil, fmt.Errorf("can not execute statement by a released session wrapper")
+	}
+	return w.ExecuteWithParameter(stmt, map[string]interface{}{})
+}
+
+func (w *SessionWrapper) ExecuteJson(stmt string) ([]byte, error) {
+	if w.isRelease {
+		return nil, fmt.Errorf("can not execute statement by a released session wrapper")
+	}
+	return w.session.ExecuteJsonWithParameter(stmt, map[string]interface{}{})
+}
+
+func (w *SessionWrapper) ExecuteJsonWithParameter(stmt string, params map[string]interface{}) ([]byte, error) {
+	if w.isRelease {
+		return nil, fmt.Errorf("can not execute statement by a released session wrapper")
+	}
+	return w.ExecuteJsonWithParameter(stmt, params)
+}


### PR DESCRIPTION
refer to the issue
https://github.com/vesoft-inc/nebula-go/issues/215

I have tried to implement a session manager refer to the solution of java client, which mainly aim to improve performance in concurrent query. 

In current go-client:

1. we need to append "USER SPACE" prefix in each query statement, it's very inconvenient and also bring performance overheads.  
2. the GetSession function of ConnectionPool will send authenticate request to check username and password every time, it may also affect the performance in concurrent query. 

according to the reasons above,  I have tried to implement a session manager and do some simple benchmark test:


env :  16 core cpu, 32GB memory
dataset: https://docs.nebula-graph.com.cn/3.1.0/2.quick-start/4.nebula-graph-crud/

Concurrent query with "GO FROM" statment:

with session manager : 
```
function :  session_manager_test.go:56
goos: darwin
goarch: arm64
pkg: github.com/vesoft-inc/nebula-go/v3
BenchmarkSessionManager-10         10000            495182 ns/op
PASS
ok      github.com/vesoft-inc/nebula-go/v3      6.222s
```

only connection pool : 
```
session_manager_test.go:84
goos: darwin
goarch: arm64
pkg: github.com/vesoft-inc/nebula-go/v3
BenchmarkSessionPool-10            10000          13417409 ns/op
PASS
ok      github.com/vesoft-inc/nebula-go/v3      134.484s
```


I think maybe it's useful for some high QPS of latency sensitive scenarios.



