### PR TITLE
Add session pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,5 @@ run-examples:
 	go run basic_example/graph_client_basic_example.go && \
 	go run basic_example/parameter_example.go && \
 	go run gorountines_example/graph_client_goroutines_example.go && \
-	go run json_example/parse_json_example.go
+	go run json_example/parse_json_example.go && \
+	go run session_pool_example/session_pool_example.go

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For example:
 
 [Code Example with Gorountines](https://github.com/vesoft-inc/nebula-go/tree/master/gorountines_example/graph_client_goroutines_example.go)
 
+[Session Pool Example](https://github.com/vesoft-inc/nebula-go/blob/master/session_pool_example/session_pool_example.go)
 ## Licensing
 
 **Nebula GO** is under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license, so you can freely download, modify, and deploy the source code to meet your needs. You can also freely deploy **Nebula GO** as a back-end service to support your SaaS deployment.

--- a/basic_example/graph_client_basic_example.go
+++ b/basic_example/graph_client_basic_example.go
@@ -62,7 +62,7 @@ func main() {
 			"CREATE TAG IF NOT EXISTS person(name string, age int);" +
 			"CREATE EDGE IF NOT EXISTS like(likeness double)"
 
-		// Excute a query
+		// Execute a query
 		resultSet, err := session.Execute(createSchema)
 		if err != nil {
 			fmt.Print(err.Error())

--- a/client_test.go
+++ b/client_test.go
@@ -25,9 +25,8 @@ import (
 )
 
 const (
-	address = "127.0.0.1"
-	port    = 29562
-	// port     = 3699
+	address  = "127.0.0.1"
+	port     = 3699
 	username = "root"
 	password = "nebula"
 
@@ -37,20 +36,16 @@ const (
 var poolAddress = []HostAddress{
 	{
 		Host: "127.0.0.1",
-		Port: 29562,
+		Port: 3699,
 	},
-	// {
-	// 	Host: "127.0.0.1",
-	// 	Port: 3699,
-	// },
-	// {
-	// 	Host: "127.0.0.1",
-	// 	Port: 3700,
-	// },
-	// {
-	// 	Host: "127.0.0.1",
-	// 	Port: 3701,
-	// },
+	{
+		Host: "127.0.0.1",
+		Port: 3700,
+	},
+	{
+		Host: "127.0.0.1",
+		Port: 3701,
+	},
 }
 
 var nebulaLog = DefaultLogger{}
@@ -597,7 +592,7 @@ func TestPool_SingleHost(t *testing.T) {
 			username, password, err.Error())
 	}
 	defer session.Release()
-	// Excute a query
+	// Execute a query
 	resp, err := tryToExecute(session, "SHOW HOSTS;")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -1412,7 +1407,8 @@ func prepareSpace(t *testing.T, spaceName string) error {
 		t.Fatalf(err.Error())
 	}
 	checkConResp(t, query, resp)
-	time.Sleep(3 * time.Second)
+	time.Sleep(5 * time.Second)
+
 	return nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -84,20 +84,35 @@ func TestConnection(t *testing.T) {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkConResp(t, "show hosts", resp)
+	checkConResp("show hosts", resp)
 
 	resp, err = conn.execute(sessionID, "CREATE SPACE client_test(partition_num=1024, replica_factor=1, vid_type = FIXED_STRING(30));")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkConResp(t, "create space", resp)
-	resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
+	checkConResp("create space", resp)
+
+	resp, err = conn.execute(sessionID, "return 1")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkConResp(t, "drop space", resp)
+	checkConResp("return 1", resp)
+
+	resp, err = conn.execute(sessionID, "return 1")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	checkConResp("return 1", resp)
+
+	// resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
+	// if err != nil {
+	// 	t.Error(err.Error())
+	// 	return
+	// }
+	// checkConResp( "drop space", resp)
 
 	res := conn.ping()
 	if res != true {
@@ -128,20 +143,20 @@ func TestConnectionIPv6(t *testing.T) {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkConResp(t, "show hosts", resp)
+	checkConResp("show hosts", resp)
 
 	resp, err = conn.execute(sessionID, "CREATE SPACE client_test(partition_num=1024, replica_factor=1, vid_type = FIXED_STRING(30));")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkConResp(t, "create space", resp)
+	checkConResp("create space", resp)
 	resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkConResp(t, "drop space", resp)
+	checkConResp("drop space", resp)
 
 	res := conn.ping()
 	if res != true {
@@ -219,7 +234,7 @@ func TestConfigs(t *testing.T) {
 		}
 		checkResultSet(t, "create space", resp)
 
-		err = dropSpace(t, "client_test")
+		err = dropSpace("client_test")
 		if err != nil {
 			t.Fatalf(err.Error())
 			return
@@ -558,7 +573,7 @@ func TestServiceDataIO(t *testing.T) {
 		}
 		assert.Equal(t, int8(sessionCreatedTime.Hour()), localTime.GetHour())
 	}
-	err = dropSpace(t, "client_test")
+	err = dropSpace("client_test")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -607,7 +622,7 @@ func TestPool_SingleHost(t *testing.T) {
 	}
 	checkResultSet(t, "create space", resp)
 
-	err = dropSpace(t, "client_test")
+	err = dropSpace("client_test")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -897,7 +912,7 @@ func TestTimeout(t *testing.T) {
 	assert.Contains(t, resultSet.AsStringTable(), []string{"999"})
 
 	// Drop space
-	err = dropSpace(t, "client_test")
+	err = dropSpace("client_test")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -1240,10 +1255,9 @@ func checkResultSet(t *testing.T, prefix string, err *ResultSet) {
 	}
 }
 
-func checkConResp(t *testing.T, prefix string, err *graph.ExecutionResponse) {
-	t.Helper()
+func checkConResp(prefix string, err *graph.ExecutionResponse) {
 	if IsError(err) {
-		t.Errorf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, err.ErrorCode, err.ErrorMsg)
+		log.Fatalf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, err.ErrorCode, err.ErrorMsg)
 	}
 }
 
@@ -1376,9 +1390,7 @@ func loadTestData(t *testing.T, session *Session) {
 }
 
 // prepareSpace creates a space for test
-func prepareSpace(t *testing.T, spaceName string) error {
-	t.Helper()
-
+func prepareSpace(spaceName string) error {
 	hostAddress := HostAddress{Host: address, Port: port}
 	conn := newConnection(hostAddress)
 	testPoolConfig := GetDefaultConf()
@@ -1401,16 +1413,16 @@ func prepareSpace(t *testing.T, spaceName string) error {
 		" %s(partition_num=32, replica_factor=1, vid_type = FIXED_STRING(30));", spaceName)
 	resp, err := conn.execute(sessionID, query)
 	if err != nil {
-		t.Fatalf(err.Error())
+		log.Fatalf(err.Error())
 	}
-	checkConResp(t, query, resp)
+	checkConResp(query, resp)
 	time.Sleep(5 * time.Second)
 
 	return nil
 }
 
 // dropSpace drops a space. The space name should be the same as the one created in prepareSpace
-func dropSpace(t *testing.T, spaceName string) error {
+func dropSpace(spaceName string) error {
 	hostAddress := HostAddress{Host: address, Port: port}
 	conn := newConnection(hostAddress)
 	testPoolConfig := GetDefaultConf()
@@ -1434,6 +1446,6 @@ func dropSpace(t *testing.T, spaceName string) error {
 	if err != nil {
 		return err
 	}
-	checkConResp(t, query, resp)
+	checkConResp(query, resp)
 	return nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -100,19 +100,12 @@ func TestConnection(t *testing.T) {
 	}
 	checkConResp("return 1", resp)
 
-	resp, err = conn.execute(sessionID, "return 1")
+	resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkConResp("return 1", resp)
-
-	// resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
-	// if err != nil {
-	// 	t.Error(err.Error())
-	// 	return
-	// }
-	// checkConResp( "drop space", resp)
+	checkConResp("drop space", resp)
 
 	res := conn.ping()
 	if res != true {

--- a/client_test.go
+++ b/client_test.go
@@ -63,19 +63,19 @@ func logoutAndClose(conn *connection, sessionID int64) {
 }
 
 func TestConnection(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
-	conn := newConnection(hostAdress)
-	err := conn.open(hostAdress, testPoolConfig.TimeOut, nil)
+	hostAddress := HostAddress{Host: address, Port: port}
+	conn := newConnection(hostAddress)
+	err := conn.open(hostAddress, testPoolConfig.TimeOut, nil)
 	if err != nil {
 		t.Fatalf("fail to open connection, address: %s, port: %d, %s", address, port, err.Error())
 	}
 
-	authresp, authErr := conn.authenticate(username, password)
+	authResp, authErr := conn.authenticate(username, password)
 	if authErr != nil {
 		t.Fatalf("fail to authenticate, username: %s, password: %s, %s", username, password, authErr.Error())
 	}
 
-	sessionID := authresp.GetSessionID()
+	sessionID := authResp.GetSessionID()
 
 	defer logoutAndClose(conn, sessionID)
 
@@ -107,19 +107,19 @@ func TestConnection(t *testing.T) {
 }
 
 func TestConnectionIPv6(t *testing.T) {
-	hostAdress := HostAddress{Host: addressIPv6, Port: port}
-	conn := newConnection(hostAdress)
-	err := conn.open(hostAdress, testPoolConfig.TimeOut, nil)
+	hostAddress := HostAddress{Host: addressIPv6, Port: port}
+	conn := newConnection(hostAddress)
+	err := conn.open(hostAddress, testPoolConfig.TimeOut, nil)
 	if err != nil {
 		t.Fatalf("fail to open connection, address: %s, port: %d, %s", address, port, err.Error())
 	}
 
-	authresp, authErr := conn.authenticate(username, password)
+	authResp, authErr := conn.authenticate(username, password)
 	if authErr != nil {
 		t.Fatalf("fail to authenticate, username: %s, password: %s, %s", username, password, authErr.Error())
 	}
 
-	sessionID := authresp.GetSessionID()
+	sessionID := authResp.GetSessionID()
 
 	defer logoutAndClose(conn, sessionID)
 
@@ -151,9 +151,9 @@ func TestConnectionIPv6(t *testing.T) {
 }
 
 func TestConfigs(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	var configList = []PoolConfig{
 		// default
@@ -202,7 +202,7 @@ func TestConfigs(t *testing.T) {
 				username, password, err.Error())
 		}
 		defer session.Release()
-		// Excute a query
+		// Execute a query
 		resp, err := tryToExecute(session, "SHOW HOSTS;")
 		if err != nil {
 			t.Fatalf(err.Error())
@@ -231,10 +231,10 @@ func TestAuthentication(t *testing.T) {
 		password = "nebula"
 	)
 
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 
-	conn := newConnection(hostAdress)
-	err := conn.open(hostAdress, testPoolConfig.TimeOut, nil)
+	conn := newConnection(hostAddress)
+	err := conn.open(hostAddress, testPoolConfig.TimeOut, nil)
 	if err != nil {
 		t.Fatalf("fail to open connection, address: %s, port: %d, %s", address, port, err.Error())
 	}
@@ -245,8 +245,8 @@ func TestAuthentication(t *testing.T) {
 }
 
 func TestInvalidHostTimeout(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
-	hostList := []HostAddress{hostAdress}
+	hostAddress := HostAddress{Host: address, Port: port}
+	hostList := []HostAddress{hostAddress}
 
 	invalidHostList := []HostAddress{
 		{Host: "192.168.100.125", Port: 3699}, // Invalid host
@@ -269,9 +269,9 @@ func TestInvalidHostTimeout(t *testing.T) {
 }
 
 func TestServiceDataIO(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	testPoolConfig = PoolConfig{
 		TimeOut:         0 * time.Millisecond,
@@ -558,9 +558,9 @@ func TestServiceDataIO(t *testing.T) {
 }
 
 func TestPool_SingleHost(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	testPoolConfig = PoolConfig{
 		TimeOut:         0 * time.Millisecond,
@@ -604,7 +604,7 @@ func TestPool_SingleHost(t *testing.T) {
 
 func TestPool_MultiHosts(t *testing.T) {
 	hostList := poolAddress
-	// Minimun pool size < hosts number
+	// Minimum pool size < hosts number
 	multiHostsConfig := PoolConfig{
 		TimeOut:         0 * time.Millisecond,
 		IdleTime:        0 * time.Millisecond,
@@ -722,7 +722,7 @@ func TestMultiThreads(t *testing.T) {
 	assert.Equal(t, 666, pool.getIdleConnCount(), "Total number of idle connections should be 666")
 }
 
-func TestLoadbalancer(t *testing.T) {
+func TestLoadBalancer(t *testing.T) {
 	hostList := poolAddress
 	var loadPerHost = make(map[HostAddress]int)
 	testPoolConfig := PoolConfig{
@@ -808,9 +808,9 @@ func TestIdleTimeoutCleaner(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	testPoolConfig = PoolConfig{
 		TimeOut:         1000 * time.Millisecond,

--- a/client_test.go
+++ b/client_test.go
@@ -725,9 +725,6 @@ func TestMultiThreads(t *testing.T) {
 	assert.Equal(t, 666, pool.getActiveConnCount(), "Total number of active connections should be 666")
 	assert.Equal(t, 666, len(sessionList), "Total number of sessions should be 666")
 
-	// for i := 0; i < len(hostList); i++ {
-	// 	assert.Equal(t, 222, pool.GetServerWorkload(i))
-	// }
 	for i := 0; i < testPoolConfig.MaxConnPoolSize; i++ {
 		sessionList[i].Release()
 	}

--- a/configs.go
+++ b/configs.go
@@ -140,7 +140,7 @@ func NewSessionPoolConf(username, password string, opts ...SessionPoolConfOption
 		timeOut:   0 * time.Millisecond,
 		idleTime:  0 * time.Millisecond,
 		maxSize:   30,
-		minSize:   0,
+		minSize:   1,
 		hostIndex: 0,
 	}
 

--- a/configs.go
+++ b/configs.go
@@ -132,7 +132,10 @@ type SessionPoolConf struct {
 type SessionPoolConfOption func(*SessionPoolConf)
 
 // NewSessionPoolConfOpt creates a new NewSessionPoolConf with the provided options
-func NewSessionPoolConf(username, password string, opts ...SessionPoolConfOption) (*SessionPoolConf, error) {
+func NewSessionPoolConf(
+	username, password string,
+	serviceAddrs []HostAddress,
+	spaceName string, opts ...SessionPoolConfOption) (*SessionPoolConf, error) {
 	// Set default values for basic pool configs
 	newPoolConf := SessionPoolConf{
 		username:  username,
@@ -153,18 +156,6 @@ func NewSessionPoolConf(username, password string, opts ...SessionPoolConfOption
 		return nil, err
 	}
 	return &newPoolConf, nil
-}
-
-func WithServiceAddrs(serviceAddrs []HostAddress) SessionPoolConfOption {
-	return func(conf *SessionPoolConf) {
-		conf.serviceAddrs = serviceAddrs
-	}
-}
-
-func WithSpaceName(spaceName string) SessionPoolConfOption {
-	return func(conf *SessionPoolConf) {
-		conf.spaceName = spaceName
-	}
 }
 
 func WithSSLConfig(sslConfig *tls.Config) SessionPoolConfOption {

--- a/configs.go
+++ b/configs.go
@@ -109,11 +109,11 @@ func openAndReadFile(path string) ([]byte, error) {
 // SessionPoolConf is the configs of a session pool
 // Note that the space name is bound to the session pool for its lifetime
 type SessionPoolConf struct {
-	Username     string        // username for authentication
-	Password     string        // password for authentication
-	ServiceAddrs []HostAddress // service addresses for session pool
+	username     string        // username for authentication
+	password     string        // password for authentication
+	serviceAddrs []HostAddress // service addresses for session pool
 	hostIndex    int           // index of the host in ServiceAddrs that the next new session will connect to
-	SpaceName    string        // The space name that all sessions in the pool are bound to
+	spaceName    string        // The space name that all sessions in the pool are bound to
 	sslConfig    *tls.Config   // Optional SSL config for the connection
 
 	// Basic pool configs
@@ -133,10 +133,10 @@ type SessionPoolConf struct {
 // NewSessionPoolConf returns a new SessionPoolConf with given parameters
 func NewSessionPoolConf(username, password string, serviceAddrs []HostAddress, spaceName string) (*SessionPoolConf, error) {
 	newPoolConf := GetDefaultSessionConf()
-	newPoolConf.Username = username
-	newPoolConf.Password = password
-	newPoolConf.ServiceAddrs = serviceAddrs
-	newPoolConf.SpaceName = spaceName
+	newPoolConf.username = username
+	newPoolConf.password = password
+	newPoolConf.serviceAddrs = serviceAddrs
+	newPoolConf.spaceName = spaceName
 
 	if err := newPoolConf.checkMandatoryFields(); err != nil {
 		return nil, err
@@ -157,16 +157,16 @@ func GetDefaultSessionConf() SessionPoolConf {
 
 func (conf *SessionPoolConf) checkMandatoryFields() error {
 	// Check mandatory fields
-	if conf.Username == "" {
+	if conf.username == "" {
 		return fmt.Errorf("invalid session pool config: Username is empty")
 	}
-	if conf.Password == "" {
+	if conf.password == "" {
 		return fmt.Errorf("invalid session pool config: Password is empty")
 	}
-	if len(conf.ServiceAddrs) == 0 {
+	if len(conf.serviceAddrs) == 0 {
 		return fmt.Errorf("invalid session pool config: Service address is empty")
 	}
-	if conf.SpaceName == "" {
+	if conf.spaceName == "" {
 		return fmt.Errorf("invalid session pool config: Space name is empty")
 	}
 	return nil

--- a/configs.go
+++ b/configs.go
@@ -138,13 +138,15 @@ func NewSessionPoolConf(
 	spaceName string, opts ...SessionPoolConfOption) (*SessionPoolConf, error) {
 	// Set default values for basic pool configs
 	newPoolConf := SessionPoolConf{
-		username:  username,
-		password:  password,
-		timeOut:   0 * time.Millisecond,
-		idleTime:  0 * time.Millisecond,
-		maxSize:   30,
-		minSize:   1,
-		hostIndex: 0,
+		username:     username,
+		password:     password,
+		serviceAddrs: serviceAddrs,
+		spaceName:    spaceName,
+		timeOut:      0 * time.Millisecond,
+		idleTime:     0 * time.Millisecond,
+		maxSize:      30,
+		minSize:      1,
+		hostIndex:    0,
 	}
 
 	// Iterate the given options and apply them to the config.

--- a/configs.go
+++ b/configs.go
@@ -118,15 +118,15 @@ type SessionPoolConf struct {
 
 	// Basic pool configs
 	// Socket timeout and Socket connection timeout, unit: seconds
-	TimeOut time.Duration
+	timeOut time.Duration
 	// The idleTime of the connection, unit: seconds
 	// If connection's idle time is longer than idleTime, it will be delete
 	// 0 value means the connection will not expire
-	IdleTime time.Duration
+	idleTime time.Duration
 	// The max sessions in pool for all addresses
-	MaxSize int
+	maxSize int
 	// The min sessions in pool for all addresses
-	MinSize int
+	minSize int
 }
 
 // TODO(Aiee) add more constructors
@@ -148,11 +148,27 @@ func NewSessionPoolConf(username, password string, serviceAddrs []HostAddress, s
 // GetDefaultSessionConf returns the default config
 func GetDefaultSessionConf() SessionPoolConf {
 	return SessionPoolConf{
-		TimeOut:  0 * time.Millisecond,
-		IdleTime: 0 * time.Millisecond,
-		MaxSize:  10,
-		MinSize:  0,
+		timeOut:  0 * time.Millisecond,
+		idleTime: 0 * time.Millisecond,
+		maxSize:  10,
+		minSize:  0,
 	}
+}
+
+func (conf *SessionPoolConf) SetTimeout(timeout time.Duration) {
+	conf.timeOut = timeout
+}
+
+func (conf *SessionPoolConf) SetIdleTime(idleTime time.Duration) {
+	conf.idleTime = idleTime
+}
+
+func (conf *SessionPoolConf) SetMaxSize(maxSize int) {
+	conf.maxSize = maxSize
+}
+
+func (conf *SessionPoolConf) SetMinSize(minSize int) {
+	conf.minSize = minSize
 }
 
 func (conf *SessionPoolConf) checkMandatoryFields() error {
@@ -176,20 +192,20 @@ func (conf *SessionPoolConf) checkMandatoryFields() error {
 // sets a default value if the given field value is invalid
 func (conf *SessionPoolConf) checkBasicFields(log Logger) {
 	// Check pool related fields, use default value if the given value is invalid
-	if conf.TimeOut < 0 {
-		conf.TimeOut = 0 * time.Millisecond
+	if conf.timeOut < 0 {
+		conf.timeOut = 0 * time.Millisecond
 		log.Warn("Illegal Timeout value, the default value of 0 second has been applied")
 	}
-	if conf.IdleTime < 0 {
-		conf.IdleTime = 0 * time.Millisecond
+	if conf.idleTime < 0 {
+		conf.idleTime = 0 * time.Millisecond
 		log.Warn("Invalid IdleTime value, the default value of 0 second has been applied")
 	}
-	if conf.MaxSize < 1 {
-		conf.MaxSize = 10
+	if conf.maxSize < 1 {
+		conf.maxSize = 10
 		log.Warn("Invalid MaxSize value, the default value of 10 has been applied")
 	}
-	if conf.MinSize < 0 {
-		conf.MinSize = 0
+	if conf.minSize < 0 {
+		conf.minSize = 0
 		log.Warn("Invalid MinSize value, the default value of 0 has been applied")
 	}
 }

--- a/connection.go
+++ b/connection.go
@@ -163,7 +163,7 @@ func (cn *connection) ping() bool {
 	return err == nil
 }
 
-// Sign out and release seesin ID
+// Sign out and release session ID
 func (cn *connection) signOut(sessionID int64) error {
 	// Release session ID to graphd
 	return cn.graph.Signout(sessionID)

--- a/connection.go
+++ b/connection.go
@@ -116,7 +116,8 @@ func (cn *connection) execute(sessionID int64, stmt string) (*graph.ExecutionRes
 	return cn.executeWithParameter(sessionID, stmt, map[string]*nebula.Value{})
 }
 
-func (cn *connection) executeWithParameter(sessionID int64, stmt string, params map[string]*nebula.Value) (*graph.ExecutionResponse, error) {
+func (cn *connection) executeWithParameter(sessionID int64, stmt string,
+	params map[string]*nebula.Value) (*graph.ExecutionResponse, error) {
 	resp, err := cn.graph.ExecuteWithParameter(sessionID, []byte(stmt), params)
 	if err != nil {
 		// reopen the connection if timeout

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -70,7 +70,7 @@ func NewSslConnectionPool(addresses []HostAddress, conf PoolConfig, sslConfig *t
 
 // initPool initializes the connection pool
 func (pool *ConnectionPool) initPool() error {
-	if err := pool.checkAddresses(); err != nil {
+	if err := checkAddresses(pool.conf.TimeOut, pool.addresses, pool.sslConfig); err != nil {
 		return fmt.Errorf("failed to open connection, error: %s ", err.Error())
 	}
 
@@ -167,7 +167,7 @@ func (pool *ConnectionPool) getIdleConn() (*connection, error) {
 
 	// Create a new connection if there is no idle connection and total connection < pool max size
 	newConn, err := pool.createConnection()
-	// TODO: If no idle avaliable, wait for timeout and reconnect
+	// TODO: If no idle available, wait for timeout and reconnect
 	return newConn, err
 }
 
@@ -181,15 +181,9 @@ func (pool *ConnectionPool) release(conn *connection) {
 	pool.idleConnectionQueue.PushBack(conn)
 }
 
-// Ping checks avaliability of host
+// Ping checks availability of host
 func (pool *ConnectionPool) Ping(host HostAddress, timeout time.Duration) error {
-	newConn := newConnection(host)
-	// Open connection to host
-	if err := newConn.open(newConn.severAddress, timeout, pool.sslConfig); err != nil {
-		return err
-	}
-	newConn.close()
-	return nil
+	return pingAddress(host, timeout, pool.sslConfig)
 }
 
 // Close closes all connection
@@ -259,7 +253,7 @@ func removeFromList(l *list.List, conn *connection) {
 // Compare total connection number with pool max size and return a connection if capable
 func (pool *ConnectionPool) createConnection() (*connection, error) {
 	totalConn := pool.idleConnectionQueue.Len() + pool.activeConnectionQueue.Len()
-	// If no idle avaliable and the number of total connection reaches the max pool size, return error/wait for timeout
+	// If no idle available and the number of total connection reaches the max pool size, return error/wait for timeout
 	if totalConn >= pool.conf.MaxConnPoolSize {
 		return nil, fmt.Errorf("failed to get connection: No valid connection" +
 			" in the idle queue and connection number has reached the pool capacity")
@@ -342,15 +336,28 @@ func (pool *ConnectionPool) timeoutConnectionList() (closing []*connection) {
 	return
 }
 
-func (pool *ConnectionPool) checkAddresses() error {
+// checkAddresses checks addresses availability
+// It opens a temporary connection to each address and closes it immediately.
+// If no error is returned, the addresses are available.
+func checkAddresses(confTimeout time.Duration, addresses []HostAddress, sslConfig *tls.Config) error {
 	var timeout = 3 * time.Second
-	if pool.conf.TimeOut != 0 && pool.conf.TimeOut < timeout {
-		timeout = pool.conf.TimeOut
+	if confTimeout != 0 && confTimeout < timeout {
+		timeout = confTimeout
 	}
-	for _, address := range pool.addresses {
-		if err := pool.Ping(address, timeout); err != nil {
+	for _, address := range addresses {
+		if err := pingAddress(address, timeout, sslConfig); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func pingAddress(address HostAddress, timeout time.Duration, sslConfig *tls.Config) error {
+	newConn := newConnection(address)
+	defer newConn.close()
+	// Open connection to host
+	if err := newConn.open(newConn.severAddress, timeout, sslConfig); err != nil {
+		return err
 	}
 	return nil
 }

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -190,6 +190,8 @@ func (pool *ConnectionPool) Ping(host HostAddress, timeout time.Duration) error 
 func (pool *ConnectionPool) Close() {
 	pool.rwLock.Lock()
 	defer pool.rwLock.Unlock()
+
+	//TODO(Aiee) merge 2 lists and close all connections
 	idleLen := pool.idleConnectionQueue.Len()
 	activeLen := pool.activeConnectionQueue.Len()
 

--- a/connection_pool.go
+++ b/connection_pool.go
@@ -129,6 +129,7 @@ func (pool *ConnectionPool) GetSession(username, password string) (*Session, err
 		sessionID:    sessID,
 		connection:   conn,
 		connPool:     pool,
+		sessPool:     nil,
 		log:          pool.log,
 		timezoneInfo: timezoneInfo{timezoneOffset, timezoneName},
 	}

--- a/gorountines_example/graph_client_goroutines_example.go
+++ b/gorountines_example/graph_client_goroutines_example.go
@@ -67,7 +67,7 @@ func main() {
 				"CREATE TAG IF NOT EXISTS person(name string, age int);" +
 				"CREATE EDGE IF NOT EXISTS like(likeness double)"
 
-			// Excute a query
+			// Execute a query
 			resultSet, err := session.Execute(createSchema)
 			if err != nil {
 				fmt.Print(err.Error())

--- a/session.go
+++ b/session.go
@@ -68,14 +68,11 @@ func (session *Session) ExecuteWithParameter(stmt string, params map[string]inte
 	if session.connection == nil {
 		return nil, fmt.Errorf("failed to execute: Session has been released")
 	}
-	paramsMap := make(map[string]*nebula.Value)
-	for k, v := range params {
-		nv, er := value2Nvalue(v)
-		if er != nil {
-			return nil, er
-		}
-		paramsMap[k] = nv
+	paramsMap, err := parseParams(params)
+	if err != nil {
+		return nil, err
 	}
+
 	execFunc := func() (interface{}, error) {
 		resp, err := session.connection.executeWithParameter(session.sessionID, stmt, paramsMap)
 		if err != nil {
@@ -274,13 +271,9 @@ func slice2Nlist(list []interface{}) (*nebula.NList, error) {
 // construct map to nebula.NMap
 func map2Nmap(m map[string]interface{}) (*nebula.NMap, error) {
 	var ret nebula.NMap
-	kvs := map[string]*nebula.Value{}
-	for k, v := range m {
-		nv, err := value2Nvalue(v)
-		if err != nil {
-			return nil, err
-		}
-		kvs[k] = nv
+	kvs, err := parseParams(m)
+	if err != nil {
+		return nil, err
 	}
 	ret.Kvs = kvs
 	return &ret, nil

--- a/session.go
+++ b/session.go
@@ -236,12 +236,13 @@ func (session *Session) GetSessionID() int64 {
 	return session.sessionID
 }
 
+// Ping checks if the session is valid
 func (session *Session) Ping() error {
 	if session.connection == nil {
 		return fmt.Errorf("failed to ping: Session has been released")
 	}
 	// send ping request
-	resp, err := session.Execute(`RETURN "client ping"`)
+	resp, err := session.Execute(`RETURN "NEBULA GO PING"`)
 	// check connection level error
 	if err != nil {
 		return fmt.Errorf("session ping failed, %s" + err.Error())

--- a/session_pool.go
+++ b/session_pool.go
@@ -1,0 +1,321 @@
+/*
+ *
+ * Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ *
+ */
+
+package nebula_go
+
+import (
+	"container/list"
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/vesoft-inc/nebula-go/v3/nebula"
+)
+
+// SessionPool is a pool that manages sessions internally.
+//
+// Usage:
+// Construct
+// sessionPool = newSessionPool(conf)
+//
+// Initialize
+// sessionPool.init()
+//
+// Execute query
+// result = sessionPool.execute("query")
+//
+// Release:
+// sessionPool.close()
+type SessionPool struct {
+	idleSessions   list.List
+	activeSessions list.List
+	conf           SessionPoolConf
+	tz             timezoneInfo
+	log            Logger
+	closed         bool
+	cleanerChan    chan struct{} //notify when pool is close
+	mu             sync.Mutex
+	sslConfig      *tls.Config
+}
+
+// NewSessionPool creates a new session pool with the given configs.
+func NewSessionPool(conf SessionPoolConf, log Logger) (*SessionPool, error) {
+	// check the config
+	conf.checkBasicFields(log)
+
+	newSessionPool := &SessionPool{
+		conf: conf,
+	}
+
+	// init the pool
+	if err := newSessionPool.init(); err != nil {
+		return nil, fmt.Errorf("failed to create a new session pool, %s", err.Error())
+	}
+
+	return newSessionPool, nil
+}
+
+// init initializes the session pool.
+func (pool *SessionPool) init() error {
+	// check the hosts status
+	if err := checkAddresses(pool.conf.TimeOut, pool.conf.ServiceAddrs, pool.sslConfig); err != nil {
+		return fmt.Errorf("failed to initialize the session pool, %s", err.Error())
+	}
+
+	// create sessions to fulfill the min connection size
+
+	return nil
+}
+
+// Execute returns the result of the given query as a ResultSet
+func (pool *SessionPool) Execute(stmt string) (*ResultSet, error) {
+	return pool.ExecuteWithParameter(stmt, map[string]interface{}{})
+}
+
+// ExecuteWithParameter returns the result of the given query as a ResultSet
+func (pool *SessionPool) ExecuteWithParameter(stmt string, params map[string]interface{}) (*ResultSet, error) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	// Get a session from the pool
+	session, err := pool.getIdleSession()
+	if err != nil {
+		return nil, err
+	}
+	// check the session is valid
+	if session.connection == nil {
+		return nil, fmt.Errorf("failed to execute: Session has been released")
+	}
+	// parse params
+	paramsMap, err := parseParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Execute the query
+	resp, err := session.connection.executeWithParameter(session.sessionID, stmt, paramsMap)
+	if err != nil {
+		return nil, err
+	}
+	resSet, err := genResultSet(resp, session.timezoneInfo)
+	if err != nil {
+		return nil, err
+	}
+	return resSet, err
+}
+
+// ExecuteJson returns the result of the given query as a json string
+// Date and Datetime will be returned in UTC
+//	JSON struct:
+// {
+//     "results":[
+//         {
+//             "columns":[
+//             ],
+//             "data":[
+//                 {
+//                     "row":[
+//                         "row-data"
+//                     ],
+//                     "meta":[
+//                         "metadata"
+//                     ]
+//                 }
+//             ],
+//             "latencyInUs":0,
+//             "spaceName":"",
+//             "planDesc ":{
+//                 "planNodeDescs":[
+//                     {
+//                         "name":"",
+//                         "id":0,
+//                         "outputVar":"",
+//                         "description":{
+//                             "key":""
+//                         },
+//                         "profiles":[
+//                             {
+//                                 "rows":1,
+//                                 "execDurationInUs":0,
+//                                 "totalDurationInUs":0,
+//                                 "otherStats":{}
+//                             }
+//                         ],
+//                         "branchInfo":{
+//                             "isDoBranch":false,
+//                             "conditionNodeId":-1
+//                         },
+//                         "dependencies":[]
+//                     }
+//                 ],
+//                 "nodeIndexMap":{},
+//                 "format":"",
+//                 "optimize_time_in_us":0
+//             },
+//             "comment ":""
+//         }
+//     ],
+//     "errors":[
+//         {
+//       		"code": 0,
+//       		"message": ""
+//         }
+//     ]
+// }
+func (pool *SessionPool) ExecuteJson(stmt string) ([]byte, error) {
+	return pool.ExecuteJsonWithParameter(stmt, map[string]interface{}{})
+}
+
+// ExecuteJson returns the result of the given query as a json string
+// Date and Datetime will be returned in UTC
+// The result is a JSON string in the same format as ExecuteJson()
+func (pool *SessionPool) ExecuteJsonWithParameter(stmt string, params map[string]interface{}) ([]byte, error) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+	// Get a session from the pool
+	session, err := pool.getIdleSession()
+	if err != nil {
+		return nil, err
+	}
+	// check the session is valid
+	if session.connection == nil {
+		return nil, fmt.Errorf("failed to execute: Session has been released")
+	}
+	// parse params
+	paramsMap, err := parseParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := session.connection.ExecuteJsonWithParameter(session.sessionID, stmt, paramsMap)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// Close logs out all sessions and closes bonded connection.
+func (pool *SessionPool) Close() {
+	idleLen := pool.idleSessions.Len()
+	activeLen := pool.activeSessions.Len()
+
+	// iterate all sessions
+	for i := 0; i < idleLen; i++ {
+		session := pool.idleSessions.Front().Value.(*Session)
+		if session.connection == nil {
+			session.log.Warn("Session has been released")
+		} else if err := session.connection.signOut(session.sessionID); err != nil {
+			session.log.Warn(fmt.Sprintf("Sign out failed, %s", err.Error()))
+		}
+		// close connection
+		session.connection.close()
+		pool.idleSessions.Remove(pool.idleSessions.Front())
+	}
+	for i := 0; i < activeLen; i++ {
+		session := pool.activeSessions.Front().Value.(*Session)
+		if session.connection == nil {
+			session.log.Warn("Session has been released")
+		} else if err := session.connection.signOut(session.sessionID); err != nil {
+			session.log.Warn(fmt.Sprintf("Sign out failed, %s", err.Error()))
+		}
+		// close connection
+		session.connection.close()
+		pool.activeSessions.Remove(pool.activeSessions.Front())
+	}
+
+	pool.closed = true
+	if pool.cleanerChan != nil {
+		close(pool.cleanerChan)
+	}
+}
+
+// newSession creates a new session and returns it.
+func (pool *SessionPool) newSession() (*Session, error) {
+
+	graphAddr := pool.getNextAddr()
+	cn := connection{
+		severAddress: graphAddr,
+		timeout:      0 * time.Millisecond,
+		returnedAt:   time.Now(),
+		sslConfig:    nil,
+		graph:        nil,
+	}
+
+	// open a new connection
+	if err := cn.open(cn.severAddress, pool.conf.TimeOut, nil); err != nil {
+		return nil, fmt.Errorf("failed to create a net.Conn-backed Transport,: %s", err.Error())
+	}
+
+	// authenticate with username and password to get a new session
+	resp, err := cn.authenticate(pool.conf.Username, pool.conf.Password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a new session: %s", err.Error())
+	}
+	sessID := resp.GetSessionID()
+	timezoneOffset := resp.GetTimeZoneOffsetSeconds()
+	timezoneName := resp.GetTimeZoneName()
+	// Create new session
+	newSession := Session{
+		sessionID:    sessID,
+		connection:   &cn,
+		connPool:     nil,
+		log:          pool.log,
+		timezoneInfo: timezoneInfo{timezoneOffset, timezoneName},
+	}
+	err = newSession.Ping()
+	if err != nil {
+		return nil, err
+	}
+
+	return &newSession, nil
+}
+
+// getNextAddr returns the next address in the address list using simple round robin approach.
+func (pool *SessionPool) getNextAddr() HostAddress {
+	if pool.conf.hostIndex == len(pool.conf.ServiceAddrs) {
+		pool.conf.hostIndex = 0
+	}
+	host := pool.conf.ServiceAddrs[pool.conf.hostIndex]
+	pool.conf.hostIndex++
+	return host
+}
+
+// getSession returns a available session.
+func (pool *SessionPool) getIdleSession() (*Session, error) {
+	// Get a session from the idle queue if possible
+	if pool.idleSessions.Len() > 0 {
+		session := pool.idleSessions.Remove(pool.idleSessions.Front()).(*Session)
+		pool.activeSessions.PushBack(session)
+		return session, nil
+	} else if pool.activeSessions.Len() < pool.conf.MaxSize {
+		// Create a new session if the total number of sessions is less than the max size
+		session, err := pool.newSession()
+		if err != nil {
+			return nil, err
+		}
+		pool.activeSessions.PushBack(session)
+		return session, nil
+	}
+	// There is no available session in the pool and the total session count has reached the limit
+	return nil, fmt.Errorf("failed to get session: no session available in the" +
+		" session pool and the total session count has reached the limit")
+}
+
+// parseParams converts the params map to a map of nebula.Value
+func parseParams(params map[string]interface{}) (map[string]*nebula.Value, error) {
+	paramsMap := make(map[string]*nebula.Value)
+	for k, v := range params {
+		nv, err := value2Nvalue(v)
+		if err != nil {
+			return nil, err
+		}
+		paramsMap[k] = nv
+	}
+	return paramsMap, nil
+}

--- a/session_pool.go
+++ b/session_pool.go
@@ -101,6 +101,11 @@ func (pool *SessionPool) Execute(stmt string) (*ResultSet, error) {
 // TODO(Aiee) add reconnect
 // ExecuteWithParameter returns the result of the given query as a ResultSet
 func (pool *SessionPool) ExecuteWithParameter(stmt string, params map[string]interface{}) (*ResultSet, error) {
+	// Check if the pool is closed
+	if pool.closed {
+		return nil, fmt.Errorf("failed to execute: Session pool has been closed")
+	}
+
 	// Get a session from the pool
 	session, err := pool.getIdleSession()
 	if err != nil {

--- a/session_pool_example/session_pool_example.go
+++ b/session_pool_example/session_pool_example.go
@@ -1,0 +1,199 @@
+/*
+ *
+ * Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ *
+ */
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	nebula "github.com/vesoft-inc/nebula-go/v3"
+)
+
+const (
+	address = "127.0.0.1"
+	// The default port of NebulaGraph 2.x is 9669.
+	// 3699 is only for testing.
+	port     = 3699
+	username = "root"
+	password = "nebula"
+)
+
+// Initialize logger
+var log = nebula.DefaultLogger{}
+
+func main() {
+	prepareSpace()
+	hostAddress := nebula.HostAddress{Host: address, Port: port}
+
+	// Create configs for session pool
+	config, err := nebula.NewSessionPoolConf("root", "nebula", []nebula.HostAddress{hostAddress}, "example_space")
+	if err != nil {
+		log.Fatal(fmt.Sprintf("failed to create session pool config, %s", err.Error()))
+	}
+
+	// create session pool
+	sessionPool, err := nebula.NewSessionPool(*config, nebula.DefaultLogger{})
+	if err != nil {
+		log.Fatal(fmt.Sprintf("failed to initialize session pool, %s", err.Error()))
+	}
+	defer sessionPool.Close()
+
+	checkResultSet := func(prefix string, res *nebula.ResultSet) {
+		if !res.IsSucceed() {
+			log.Fatal(fmt.Sprintf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, res.GetErrorCode(), res.GetErrorMsg()))
+		}
+	}
+
+	// execute query
+	{
+		insertVertexes := "INSERT VERTEX person(name, age) VALUES " +
+			"'Bob':('Bob', 10), " +
+			"'Lily':('Lily', 9), " +
+			"'Tom':('Tom', 10), " +
+			"'Jerry':('Jerry', 13), " +
+			"'John':('John', 11);"
+
+		// Insert multiple vertexes
+		resultSet, err := sessionPool.Execute(insertVertexes)
+		if err != nil {
+			fmt.Print(err.Error())
+			return
+		}
+		checkResultSet(insertVertexes, resultSet)
+	}
+	{
+		// Insert multiple edges
+		insertEdges := "INSERT EDGE like(likeness) VALUES " +
+			"'Bob'->'Lily':(80.0), " +
+			"'Bob'->'Tom':(70.0), " +
+			"'Lily'->'Jerry':(84.0), " +
+			"'Tom'->'Jerry':(68.3), " +
+			"'Bob'->'John':(97.2);"
+
+		resultSet, err := sessionPool.Execute(insertEdges)
+		if err != nil {
+			fmt.Print(err.Error())
+			return
+		}
+		checkResultSet(insertEdges, resultSet)
+	}
+	// Extract data from the resultSet
+	{
+		query := "GO FROM 'Bob' OVER like YIELD $^.person.name, $^.person.age, like.likeness"
+		// Send query in goroutine
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		var resultSet *nebula.ResultSet
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+
+			resultSet, err = sessionPool.Execute(query)
+			if err != nil {
+				fmt.Print(err.Error())
+				return
+			}
+			checkResultSet(query, resultSet)
+		}(&wg)
+		wg.Wait()
+
+		// Get all column names from the resultSet
+		colNames := resultSet.GetColNames()
+		fmt.Printf("column names: %s\n", strings.Join(colNames, ", "))
+
+		// Get a row from resultSet
+		record, err := resultSet.GetRowValuesByIndex(0)
+		if err != nil {
+			log.Error(err.Error())
+		}
+		// Print whole row
+		fmt.Printf("row elements: %s\n", record.String())
+		// Get a value in the row by column index
+		valueWrapper, err := record.GetValueByIndex(0)
+		if err != nil {
+			log.Error(err.Error())
+		}
+		// Get type of the value
+		fmt.Printf("valueWrapper type: %s \n", valueWrapper.GetType())
+		// Check if valueWrapper is a string type
+		if valueWrapper.IsString() {
+			// Convert valueWrapper to a string value
+			v1Str, err := valueWrapper.AsString()
+			if err != nil {
+				log.Error(err.Error())
+			}
+			fmt.Printf("Result of ValueWrapper.AsString(): %s\n", v1Str)
+		}
+		// Print ValueWrapper using String()
+		fmt.Printf("Print using ValueWrapper.String(): %s", valueWrapper.String())
+	}
+	// Drop space
+	{
+		query := "DROP SPACE IF EXISTS example_space"
+		// Send query
+		resultSet, err := sessionPool.Execute(query)
+		if err != nil {
+			fmt.Print(err.Error())
+			return
+		}
+		checkResultSet(query, resultSet)
+	}
+	fmt.Print("\n")
+	log.Info("Nebula Go Client Session Pool Example Finished")
+}
+
+// Just a helper function to create a space for this example to run.
+func prepareSpace() {
+	hostAddress := nebula.HostAddress{Host: address, Port: port}
+	hostList := []nebula.HostAddress{hostAddress}
+	// Create configs for connection pool using default values
+	testPoolConfig := nebula.GetDefaultConf()
+
+	// Initialize connection pool
+	pool, err := nebula.NewConnectionPool(hostList, testPoolConfig, log)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Fail to initialize the connection pool, host: %s, port: %d, %s", address, port, err.Error()))
+	}
+	// Close all connections in the pool
+	defer pool.Close()
+
+	// Create session
+	session, err := pool.GetSession(username, password)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Fail to create a new session from connection pool, username: %s, password: %s, %s",
+			username, password, err.Error()))
+	}
+	// Release session and return connection back to connection pool
+	defer session.Release()
+
+	checkResultSet := func(prefix string, res *nebula.ResultSet) {
+		if !res.IsSucceed() {
+			log.Fatal(fmt.Sprintf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, res.GetErrorCode(), res.GetErrorMsg()))
+		}
+	}
+
+	{
+		// Prepare the query
+		createSchema := "CREATE SPACE IF NOT EXISTS example_space(vid_type=FIXED_STRING(20)); " +
+			"USE example_space;" +
+			"CREATE TAG IF NOT EXISTS person(name string, age int);" +
+			"CREATE EDGE IF NOT EXISTS like(likeness double)"
+
+		// Execute a query
+		resultSet, err := session.Execute(createSchema)
+		if err != nil {
+			fmt.Print(err.Error())
+			return
+		}
+		checkResultSet(createSchema, resultSet)
+	}
+	time.Sleep(5 * time.Second)
+	log.Info("Space example_space was created")
+}

--- a/session_pool_example/session_pool_example.go
+++ b/session_pool_example/session_pool_example.go
@@ -34,7 +34,12 @@ func main() {
 	hostAddress := nebula.HostAddress{Host: address, Port: port}
 
 	// Create configs for session pool
-	config, err := nebula.NewSessionPoolConf("root", "nebula", []nebula.HostAddress{hostAddress}, "example_space")
+	config, err := nebula.NewSessionPoolConf(
+		nebula.WithUsername("root"),
+		nebula.WithPassword("nebula"),
+		nebula.WithServiceAddrs([]nebula.HostAddress{hostAddress}),
+		nebula.WithSpaceName("example_space"),
+	)
 	if err != nil {
 		log.Fatal(fmt.Sprintf("failed to create session pool config, %s", err.Error()))
 	}

--- a/session_pool_example/session_pool_example.go
+++ b/session_pool_example/session_pool_example.go
@@ -35,8 +35,8 @@ func main() {
 
 	// Create configs for session pool
 	config, err := nebula.NewSessionPoolConf(
-		nebula.WithUsername("root"),
-		nebula.WithPassword("nebula"),
+		"root",
+		"nebula",
 		nebula.WithServiceAddrs([]nebula.HostAddress{hostAddress}),
 		nebula.WithSpaceName("example_space"),
 	)

--- a/session_pool_example/session_pool_example.go
+++ b/session_pool_example/session_pool_example.go
@@ -37,8 +37,8 @@ func main() {
 	config, err := nebula.NewSessionPoolConf(
 		"root",
 		"nebula",
-		nebula.WithServiceAddrs([]nebula.HostAddress{hostAddress}),
-		nebula.WithSpaceName("example_space"),
+		[]nebula.HostAddress{hostAddress},
+		"example_space",
 	)
 	if err != nil {
 		log.Fatal(fmt.Sprintf("failed to create session pool config, %s", err.Error()))

--- a/session_pool_test.go
+++ b/session_pool_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -61,8 +62,11 @@ func TestSessionPoolBasic(t *testing.T) {
 	assert.Equal(t, 1, sessionPool.idleSessions.Len(), "Total number of active connections should be 1")
 }
 
-func TestSessionPoolMultiThread(t *testing.T) {
-	prepareSpace(t, "client_test")
+func TestSessionPoolMultiThreadGetSession(t *testing.T) {
+	err := prepareSpace(t, "client_test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer dropSpace(t, "client_test")
 
 	hostList := poolAddress
@@ -70,77 +74,112 @@ func TestSessionPoolMultiThread(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
-	config.MaxSize = 333
+	config.maxSize = 333
 
-	// test get idle session
-	{
-		// create session pool
-		sessionPool, err := NewSessionPool(*config, DefaultLogger{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer sessionPool.Close()
+	// create session pool
+	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionPool.Close()
 
-		var wg sync.WaitGroup
-		sessCh := make(chan *Session)
-		done := make(chan bool)
-		wg.Add(sessionPool.conf.MaxSize)
+	var wg sync.WaitGroup
+	sessCh := make(chan *Session)
+	done := make(chan bool)
+	wg.Add(sessionPool.conf.maxSize)
 
-		// producer creates sessions
-		for i := 0; i < sessionPool.conf.MaxSize; i++ {
-			go func(sessCh chan<- *Session, wg *sync.WaitGroup) {
-				defer wg.Done()
-				session, err := sessionPool.getIdleSession()
-				if err != nil {
-					t.Errorf("fail to create a new session from connection pool, %s", err.Error())
-				}
-				sessCh <- session
-			}(sessCh, &wg)
-		}
-
-		// consumer consumes the session created
-		var sessionList []*Session
-		go func(sessCh <-chan *Session) {
-			for session := range sessCh {
-				sessionList = append(sessionList, session)
+	// producer create sessions
+	for i := 0; i < sessionPool.conf.maxSize; i++ {
+		go func(sessCh chan<- *Session, wg *sync.WaitGroup) {
+			defer wg.Done()
+			session, err := sessionPool.getIdleSession()
+			if err != nil {
+				t.Errorf("fail to create a new session from connection pool, %s", err.Error())
 			}
-			done <- true
-		}(sessCh)
-		wg.Wait()
-		close(sessCh)
-		<-done
-
-		assert.Equal(t, 333, sessionPool.activeSessions.Len(), "Total number of active connections should be 333")
-		assert.Equal(t, 333, len(sessionList), "Total number of result returned should be 333")
+			sessCh <- session
+		}(sessCh, &wg)
 	}
 
-	// test Execute()
-	{
-		// create session pool
-		sessionPool, err := NewSessionPool(*config, DefaultLogger{})
-		if err != nil {
-			t.Fatal(err)
+	// consumer consumes the session created
+	var sessionList []*Session
+	go func(sessCh <-chan *Session) {
+		for session := range sessCh {
+			sessionList = append(sessionList, session)
 		}
-		defer sessionPool.Close()
+		done <- true
+	}(sessCh)
+	wg.Wait()
+	close(sessCh)
+	<-done
 
-		var wg sync.WaitGroup
-		wg.Add(sessionPool.conf.MaxSize)
-
-		for i := 0; i < sessionPool.conf.MaxSize; i++ {
-			go func(wg *sync.WaitGroup) {
-				defer wg.Done()
-				_, err := sessionPool.Execute("RETURN 1")
-				if err != nil {
-					t.Errorf(err.Error())
-				}
-			}(&wg)
-		}
-		wg.Wait()
-		assert.Equal(t, 0, sessionPool.activeSessions.Len(), "Total number of active connections should be 0")
-	}
+	assert.Equalf(t, config.maxSize, sessionPool.activeSessions.Len(),
+		"Total number of active connections should be %d", config.maxSize)
+	assert.Equalf(t, config.maxSize, len(sessionList),
+		"Total number of result returned should be %d", config.maxSize)
 }
 
-// TODO(Aiee): add more test cases
+func TestSessionPoolMultiThreadExecute(t *testing.T) {
+	err := prepareSpace(t, "client_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropSpace(t, "client_test")
+
+	hostList := poolAddress
+	config, err := NewSessionPoolConf("root", "nebula", hostList, "client_test")
+	if err != nil {
+		t.Errorf("failed to create session pool config, %s", err.Error())
+	}
+	config.maxSize = 300
+
+	// create session pool
+	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionPool.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(sessionPool.conf.maxSize)
+	respCh := make(chan *ResultSet)
+	done := make(chan bool)
+
+	for i := 0; i < sessionPool.conf.maxSize; i++ {
+		go func(respCh chan<- *ResultSet, wg *sync.WaitGroup) {
+			defer wg.Done()
+			resp, err := sessionPool.Execute("SHOW HOSTS")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			respCh <- resp
+		}(respCh, &wg)
+	}
+
+	var respList []*ResultSet
+	go func(respCh <-chan *ResultSet) {
+		for resp := range respCh {
+			respList = append(respList, resp)
+		}
+		done <- true
+	}(respCh)
+	wg.Wait()
+	close(respCh)
+	<-done
+
+	// should generate config.maxSize results
+	assert.Equalf(t, config.maxSize, len(respList),
+		"Total number of response should be %d", config.maxSize)
+
+	// should be 0 active sessions because they are put back to idle session list after
+	// query execution
+	assert.Equal(t, 0, sessionPool.activeSessions.Len(),
+		"Total number of active sessions should be 0")
+	// Note that here the idle session number may not be equal to the max size because once the query execution
+	// finished, the session will be put back to the idle session list and could be reused by other goroutines.
+}
+
+// This test is used to test if the space bond to session is the same as the space in the session pool config after executing
+// a query contains `USE <space_name>` statement.
 func TestSessionPoolSpaceChange(t *testing.T) {
 	err := prepareSpace(t, "test_space_1")
 	if err != nil {
@@ -160,6 +199,9 @@ func TestSessionPoolSpaceChange(t *testing.T) {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
 
+	// allow only one session in the pool so it is easier to test
+	config.maxSize = 1
+
 	// create session pool
 	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
 	if err != nil {
@@ -167,11 +209,73 @@ func TestSessionPoolSpaceChange(t *testing.T) {
 	}
 	defer sessionPool.Close()
 
-	// execute query
+	// execute query in test_space_2
 	resultSet, err := sessionPool.Execute("USE test_space_2; SHOW HOSTS;")
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.True(t, resultSet.IsSucceed(), fmt.Errorf("error code: %d, error msg: %s",
 		resultSet.GetErrorCode(), resultSet.GetErrorMsg()))
+
+	// this query should be executed in test_space_1
+	resultSet, err = sessionPool.Execute("SHOW HOSTS;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, resultSet.IsSucceed(), fmt.Errorf("error code: %d, error msg: %s",
+		resultSet.GetErrorCode(), resultSet.GetErrorMsg()))
+	assert.Equal(t, resultSet.GetSpaceName(), "test_space_1", "space name should be test_space_1")
+}
+
+func TestIdleSessionCleaner(t *testing.T) {
+	err := prepareSpace(t, "client_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropSpace(t, "client_test")
+
+	hostAddress := HostAddress{Host: address, Port: port}
+	idleTimeoutConfig, err := NewSessionPoolConf("root", "nebula", []HostAddress{hostAddress}, "client_test")
+	if err != nil {
+		t.Errorf("failed to create session pool config, %s", err.Error())
+	}
+
+	idleTimeoutConfig.idleTime = 2 * time.Second
+	idleTimeoutConfig.minSize = 5
+	idleTimeoutConfig.maxSize = 100
+
+	// create session pool
+	sessionPool, err := NewSessionPool(*idleTimeoutConfig, DefaultLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionPool.Close()
+	assert.Equal(t, 5, sessionPool.activeSessions.Len()+sessionPool.idleSessions.Len(), "Total number of sessions should be 5")
+
+	// execute multiple queries so more sessions will be created
+	var wg sync.WaitGroup
+	wg.Add(sessionPool.conf.maxSize)
+
+	for i := 0; i < sessionPool.conf.maxSize; i++ {
+		go func(wg *sync.WaitGroup) {
+			defer wg.Done()
+			_, err := sessionPool.Execute("RETURN 1")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+		}(&wg)
+	}
+	wg.Wait()
+
+	// wait for sessions to be idle
+	time.Sleep(idleTimeoutConfig.idleTime)
+
+	// the minimum interval for cleanup is 1 minute, so in CI we need to trigger cleanup manually
+	sessionPool.cleanerChan <- struct{}{}
+	time.Sleep(idleTimeoutConfig.idleTime + 1)
+
+	// after cleanup, the total session should be 5 which is the minSize
+	assert.Truef(t, sessionPool.GetTotalSessionCount() == sessionPool.conf.minSize,
+		"Total number of session should be %d, but got %d",
+		sessionPool.conf.minSize, sessionPool.GetTotalSessionCount())
 }

--- a/session_pool_test.go
+++ b/session_pool_test.go
@@ -1,0 +1,70 @@
+//go:build integration
+// +build integration
+
+/*
+ *
+ * Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ *
+ */
+package nebula_go
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSessionPool_Basic(t *testing.T) {
+	err := prepareSpace(t)
+	assert.Nil(t, err)
+
+	hostAddress := HostAddress{Host: address, Port: 29562}
+	config, err := NewSessionPoolConf("root", "nebula", []HostAddress{hostAddress}, "nba")
+	if err != nil {
+		t.Errorf("failed to create session pool config, %s", err.Error())
+	}
+
+	// create session pool
+	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionPool.Close()
+
+	// execute query
+	resultSet, err := sessionPool.Execute("RETURN 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, resultSet.IsSucceed())
+}
+
+func prepareSpace(t *testing.T) error {
+	hostAddress := HostAddress{Host: address, Port: 29562}
+	conn := newConnection(hostAddress)
+	testPoolConfig := GetDefaultConf()
+
+	err := conn.open(hostAddress, testPoolConfig.TimeOut, nil)
+	if err != nil {
+		t.Fatalf("fail to open connection, address: %s, port: %d, %s", address, port, err.Error())
+	}
+
+	authResp, authErr := conn.authenticate(username, password)
+	if authErr != nil {
+		t.Fatalf("fail to authenticate, username: %s, password: %s, %s", username, password, authErr.Error())
+	}
+
+	sessionID := authResp.GetSessionID()
+
+	defer logoutAndClose(conn, sessionID)
+
+	resp, err := conn.execute(sessionID, "CREATE SPACE IF NOT EXISTS"+
+		" client_test(partition_num=32, replica_factor=1, vid_type = FIXED_STRING(30));")
+	if err != nil {
+		return err
+	}
+	checkConResp(t, "create space", resp)
+	return nil
+}

--- a/session_pool_test.go
+++ b/session_pool_test.go
@@ -26,7 +26,8 @@ func TestSessionPoolInvalidConfig(t *testing.T) {
 	_, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs([]HostAddress{hostAddress}),
+		[]HostAddress{hostAddress},
+		"",
 	)
 	assert.Contains(t, err.Error(), "invalid session pool config: Space name is empty",
 		"error message should contain Space name is empty")
@@ -35,15 +36,16 @@ func TestSessionPoolInvalidConfig(t *testing.T) {
 	_, err = NewSessionPoolConf(
 		"",
 		"",
-		WithServiceAddrs([]HostAddress{hostAddress}),
-		WithSpaceName("client_test"),
+		[]HostAddress{hostAddress},
+		"client_test",
 	)
 	assert.Contains(t, err.Error(), "Username is empty", "error message should contain Username is empty")
 
 	// No service address
 	_, err = NewSessionPoolConf("root",
 		"nebula",
-		WithSpaceName("client_test"),
+		[]HostAddress{},
+		"client_test",
 	)
 	assert.Contains(t, err.Error(), "invalid session pool config: Service address is empty",
 		"error message should contain Service address is empty")
@@ -57,8 +59,8 @@ func TestSessionPoolBasic(t *testing.T) {
 	config, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs([]HostAddress{hostAddress}),
-		WithSpaceName("client_test"))
+		[]HostAddress{hostAddress},
+		"client_test")
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
@@ -93,8 +95,8 @@ func TestSessionPoolMultiThreadGetSession(t *testing.T) {
 	config, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs(hostList),
-		WithSpaceName("client_test"))
+		hostList,
+		"client_test")
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
@@ -153,8 +155,8 @@ func TestSessionPoolMultiThreadExecute(t *testing.T) {
 	config, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs(hostList),
-		WithSpaceName("client_test"))
+		hostList,
+		"client_test")
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
@@ -225,8 +227,8 @@ func TestSessionPoolSpaceChange(t *testing.T) {
 	config, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs([]HostAddress{hostAddress}),
-		WithSpaceName("test_space_1"))
+		[]HostAddress{hostAddress},
+		"test_space_1")
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
@@ -270,8 +272,8 @@ func TestIdleSessionCleaner(t *testing.T) {
 	idleTimeoutConfig, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs([]HostAddress{hostAddress}),
-		WithSpaceName("client_test"))
+		[]HostAddress{hostAddress},
+		"client_test")
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
@@ -329,8 +331,8 @@ func BenchmarkConcurrency(b *testing.B) {
 	config, err := NewSessionPoolConf(
 		"root",
 		"nebula",
-		WithServiceAddrs([]HostAddress{hostAddress}),
-		WithSpaceName("client_test"),
+		[]HostAddress{hostAddress},
+		"client_test",
 		WithMaxSize(1200),
 		WithMinSize(1000))
 	if err != nil {

--- a/session_pool_test.go
+++ b/session_pool_test.go
@@ -18,6 +18,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestSessionPoolInvalidConfig(t *testing.T) {
+	hostAddress := HostAddress{Host: address, Port: port}
+	_, err := NewSessionPoolConf("root", "nebula", []HostAddress{hostAddress}, "")
+	assert.Contains(t, err.Error(), "invalid session pool config: Space name is empty",
+		"error message should contain Space name is empty")
+
+	_, err = NewSessionPoolConf("", "", []HostAddress{hostAddress}, "test")
+	assert.Contains(t, err.Error(), "Username is empty", "error message should contain Username is empty")
+
+	_, err = NewSessionPoolConf("root", "nebula", []HostAddress{}, "")
+	assert.Contains(t, err.Error(), "invalid session pool config: Service address is empty",
+		"error message should contain Service address is empty")
+}
+
 func TestSessionPoolBasic(t *testing.T) {
 	prepareSpace(t, "client_test")
 	defer dropSpace(t, "client_test")
@@ -56,7 +70,7 @@ func TestSessionPoolMultiThread(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create session pool config, %s", err.Error())
 	}
-	config.MaxSize = 666
+	config.MaxSize = 333
 
 	// test get idle session
 	{
@@ -96,34 +110,68 @@ func TestSessionPoolMultiThread(t *testing.T) {
 		close(sessCh)
 		<-done
 
-		assert.Equal(t, 666, sessionPool.activeSessions.Len(), "Total number of active connections should be 666")
-		assert.Equal(t, 666, len(sessionList), "Total number of result returned should be 666")
+		assert.Equal(t, 333, sessionPool.activeSessions.Len(), "Total number of active connections should be 333")
+		assert.Equal(t, 333, len(sessionList), "Total number of result returned should be 333")
 	}
-	// // test Execute()
-	// {
-	// 	// create session pool
-	// 	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
-	// 	if err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// 	defer sessionPool.Close()
 
-	// 	var wg sync.WaitGroup
-	// 	wg.Add(sessionPool.conf.MaxSize)
+	// test Execute()
+	{
+		// create session pool
+		sessionPool, err := NewSessionPool(*config, DefaultLogger{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer sessionPool.Close()
 
-	// 	wg.Add(sessionPool.conf.MaxSize)
-	// 	for i := 0; i < sessionPool.conf.MaxSize; i++ {
-	// 		go func(wg *sync.WaitGroup) {
-	// 			defer wg.Done()
-	// 			_, err := sessionPool.Execute("RETURN 1")
-	// 			if err != nil {
-	// 				t.Errorf(err.Error())
-	// 			}
-	// 		}(&wg)
-	// 	}
-	// 	wg.Wait()
-	// 	assert.Equal(t, 0, sessionPool.activeSessions.Len(), "Total number of active connections should be 0")
-	// }
+		var wg sync.WaitGroup
+		wg.Add(sessionPool.conf.MaxSize)
+
+		for i := 0; i < sessionPool.conf.MaxSize; i++ {
+			go func(wg *sync.WaitGroup) {
+				defer wg.Done()
+				_, err := sessionPool.Execute("RETURN 1")
+				if err != nil {
+					t.Errorf(err.Error())
+				}
+			}(&wg)
+		}
+		wg.Wait()
+		assert.Equal(t, 0, sessionPool.activeSessions.Len(), "Total number of active connections should be 0")
+	}
 }
 
-func TestSessionPoolSpaceChange(t *testing.T) {}
+// TODO(Aiee): add more test cases
+func TestSessionPoolSpaceChange(t *testing.T) {
+	err := prepareSpace(t, "test_space_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropSpace(t, "test_space_1")
+
+	err = prepareSpace(t, "test_space_2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dropSpace(t, "test_space_2")
+
+	hostAddress := HostAddress{Host: address, Port: port}
+	config, err := NewSessionPoolConf("root", "nebula", []HostAddress{hostAddress}, "test_space_1")
+	if err != nil {
+		t.Errorf("failed to create session pool config, %s", err.Error())
+	}
+
+	// create session pool
+	sessionPool, err := NewSessionPool(*config, DefaultLogger{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionPool.Close()
+
+	// execute query
+	resultSet, err := sessionPool.Execute("USE test_space_2; SHOW HOSTS;")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, resultSet.IsSucceed(), fmt.Errorf("error code: %d, error msg: %s",
+		resultSet.GetErrorCode(), resultSet.GetErrorMsg()))
+}

--- a/session_test.go
+++ b/session_test.go
@@ -35,6 +35,12 @@ func TestSession_Execute(t *testing.T) {
 		if !reps.IsSucceed() {
 			t.Fatal(reps.resp.ErrorMsg)
 		}
+
+		// test Ping()
+		err = s.Ping()
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 	go func() {
 		for {

--- a/ssl_connection_test.go
+++ b/ssl_connection_test.go
@@ -21,9 +21,9 @@ func TestSslConnection(t *testing.T) {
 	// skip test when ssl_test is not set to true
 	skipSsl(t)
 
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	testPoolConfig = PoolConfig{
 		TimeOut:         0 * time.Millisecond,
@@ -86,9 +86,9 @@ func TestSslConnectionSelfSigned(t *testing.T) {
 	// skip test when ssl_test is not set to true
 	skipSslSelfSigned(t)
 
-	hostAdress := HostAddress{Host: address, Port: port}
+	hostAddress := HostAddress{Host: address, Port: port}
 	hostList := []HostAddress{}
-	hostList = append(hostList, hostAdress)
+	hostList = append(hostList, hostAddress)
 
 	testPoolConfig = PoolConfig{
 		TimeOut:         0 * time.Millisecond,

--- a/ssl_connection_test.go
+++ b/ssl_connection_test.go
@@ -58,7 +58,7 @@ func TestSslConnection(t *testing.T) {
 			username, password, err.Error())
 	}
 	defer session.Release()
-	// Excute a query
+	// Execute a query
 	resp, err := tryToExecute(session, "SHOW HOSTS;")
 	if err != nil {
 		t.Fatalf(err.Error())
@@ -123,7 +123,7 @@ func TestSslConnectionSelfSigned(t *testing.T) {
 			username, password, err.Error())
 	}
 	defer session.Release()
-	// Excute a query
+	// Execute a query
 	resp, err := tryToExecute(session, "SHOW HOSTS;")
 	if err != nil {
 		t.Fatalf(err.Error())


### PR DESCRIPTION
## Why we need a session pool
The purpose of adding the  `session pool` is to solve the problem caused by improperly using the connection pool. For example, a common case is that the user generates a new session, executes a query, and releases the session in a loop, like:
```
// Wrong usage of the connection pool
for(int i=0; i<100; i++) {
  // get new session
  // execute query
  // release session
}
```
This will cause huge traffic in the meta service and may crash the service.

## Usage
See `session_pool_example.go` for a more detailed example.
```go
// Create configs for session pool
config, err := nebula.NewSessionPoolConf("root", "nebula", []nebula.HostAddress{hostAddress}, "example_space")

// create session pool
sessionPool, err := nebula.NewSessionPool(*config, nebula.DefaultLogger{})
defer sessionPool.Close()

// execute query
resultSet, err := sessionPool.Execute(stmt)
```

## Limitation
There are some limitations:
1. There **MUST** be an existing `space` in the DB before initializing the session pool.
2. Each session pool is corresponding to a single **USER** and a single **Space**. This is to ensure that the user's access control is consistent. i.g. The same user may have different access privileges in different spaces. If you need to run queries in different spaces, you may have multiple session pools.
3. Every time when `sessinPool.execute()` is called, the session will execute the query in the space set in the session pool config.