### PR TITLE
move Ping after use space

### DIFF
--- a/session_pool.go
+++ b/session_pool.go
@@ -327,10 +327,6 @@ func (pool *SessionPool) newSession() (*Session, error) {
 		log:          pool.log,
 		timezoneInfo: timezoneInfo{timezoneOffset, timezoneName},
 	}
-	err = newSession.Ping()
-	if err != nil {
-		return nil, err
-	}
 
 	stmt := fmt.Sprintf("USE %s", pool.conf.spaceName)
 	createSpaceResp, err := newSession.connection.execute(newSession.sessionID, stmt)
@@ -341,6 +337,12 @@ func (pool *SessionPool) newSession() (*Session, error) {
 		return nil, fmt.Errorf("failed to use space %s: %s",
 			pool.conf.spaceName, createSpaceResp.GetErrorMsg())
 	}
+
+	err = newSession.Ping()
+	if err != nil {
+		return nil, err
+	}
+
 	return &newSession, nil
 }
 


### PR DESCRIPTION
在use space之前ping会报错：
new relation service error: create session pool: failed to create a new session pool, failed to initialize the session pool, session ping failed, %!s(MISSING)PermissionError: No permission to read schema/data.

建议把ping移到use之后，或者直接去掉，刚auth过的session应该不需要ping