### PR TITLE
fix: Close connection when remove it

### DIFF
--- a/connection_pool.go
+++ b/connection_pool.go
@@ -161,6 +161,7 @@ func (pool *ConnectionPool) getIdleConn() (*connection, error) {
 			} else {
 				tmpNextEle = ele.Next()
 				pool.idleConnectionQueue.Remove(ele)
+				ele.Value.(*connection).close()
 			}
 		}
 		if newConn == nil {


### PR DESCRIPTION
Close deprecated connections from idle queue to avoid leaks.