### PR TITLE
Update correct website URL for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ For example:
 
 ## Usage example
 
-[Simple Code Example](https://github.com/vesoft-inc/nebula-go/tree/master/basic_example/graph_client_basic_example.go)
+[Simple Code Example](https://github.com/vesoft-inc/nebula-go/blob/release-3.1/basic_example/graph_client_basic_example.go)
 
-[Code Example with Gorountines](https://github.com/vesoft-inc/nebula-go/tree/master/gorountines_example/graph_client_goroutines_example.go)
+[Code Example with Gorountines](https://github.com/vesoft-inc/nebula-go/blob/release-3.1/gorountines_example/graph_client_goroutines_example.go)
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ For example:
 
 ## Usage example
 
-[Simple Code Example](https://github.com/vesoft-inc/nebula-go/blob/release-3.1/basic_example/graph_client_basic_example.go)
+[Simple Code Example](https://github.com/vesoft-inc/nebula-go/blob/master/examples/basic_example/graph_client_basic_example.go)
 
-[Code Example with Gorountines](https://github.com/vesoft-inc/nebula-go/blob/release-3.1/gorountines_example/graph_client_goroutines_example.go)
+[Code Example with Gorountines](https://github.com/vesoft-inc/nebula-go/blob/master/examples/gorountines_example/graph_client_goroutines_example.go)
 
 ## Licensing
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
The operation initiated no issues.

#### Description:
Due to the expiration of the URL link, the Golang official website description (`https://pkg.go.dev/github.com/vesoft-inc/nebula-go/v3@v3.3.1#section-readme`) cannot normally view the module `Usage example`, which creates a bad user experience.

## How do you solve it?
Update the correct website URL link in branch `release-3.1`.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


