### PR TITLE
provide metaClient

### DIFF
--- a/meta_client.go
+++ b/meta_client.go
@@ -1,0 +1,344 @@
+/*
+ *
+ * Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ *
+ */
+
+package nebula_go
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/facebook/fbthrift/thrift/lib/go/thrift"
+	"github.com/vesoft-inc/nebula-go/v3/nebula"
+	"github.com/vesoft-inc/nebula-go/v3/nebula/meta"
+)
+
+type metaClient struct {
+	address             HostAddress
+	latestSchemaVersion int64
+	timeout             time.Duration
+	meta                *meta.MetaServiceClient
+}
+
+func NewMetaClient(address HostAddress, timeout time.Duration) *metaClient {
+	return &metaClient{
+		address:             address,
+		timeout:             timeout,
+		latestSchemaVersion: -1,
+		meta:                nil,
+	}
+}
+
+// open the metaClient socket connection
+func (client *metaClient) Open() error {
+	ip := client.address.Host
+	port := client.address.Port
+	return client.doOpen(ip, port)
+}
+
+// do open operation for metaClient
+func (client *metaClient) doOpen(ip string, port int) error {
+	newAdd := net.JoinHostPort(ip, strconv.Itoa(port))
+
+	sock, err := thrift.NewSocket(thrift.SocketAddr(newAdd), thrift.SocketTimeout(client.timeout))
+	if err != nil {
+		return fmt.Errorf("failed to create a net.Conn-backed Transport,: %s", err.Error())
+	}
+
+	bufferSize := 128 << 10
+	bufferedTranFactory := thrift.NewBufferedTransportFactory(bufferSize)
+	transport := thrift.NewHeaderTransport(bufferedTranFactory.GetTransport(sock))
+	pf := thrift.NewHeaderProtocolFactory()
+
+	client.meta = meta.NewMetaServiceClientFactory(transport, pf)
+	if err = client.meta.Open(); err != nil {
+		return fmt.Errorf("failed to open transport, error: %s", err.Error())
+	}
+
+	if !client.meta.IsOpen() {
+		return fmt.Errorf("transport is off")
+	}
+	return client.verifyClientVersion()
+}
+
+// verify the compatibility of client and server
+func (client *metaClient) verifyClientVersion() error {
+	req := meta.NewVerifyClientVersionReq()
+	resp, err := client.meta.VerifyClientVersion(req)
+	if err != nil {
+		client.close()
+		return fmt.Errorf("failed to verify client version: %s", err.Error())
+	}
+	if resp.GetCode() != nebula.ErrorCode_SUCCEEDED {
+		return fmt.Errorf("incompatible version between client and server: %s", string(resp.GetErrorMsg()))
+	}
+	return nil
+}
+
+// get all space names
+func (client *metaClient) GetSpaces() ([]string, error) {
+	req := meta.NewListSpacesReq()
+
+	resp, err := client.meta.ListSpaces(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.ListSpaces(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var spaces []string
+	for _, name := range resp.GetSpaces() {
+		spaces = append(spaces, string(name.GetName()))
+	}
+	return spaces, nil
+}
+
+// get one specific space info
+func (client *metaClient) GetSpace(spaceName string) (*meta.SpaceItem, error) {
+	req := meta.NewGetSpaceReq()
+	req.SetSpaceName([]byte(spaceName))
+	resp, err := client.meta.GetSpace(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.GetSpace(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return resp.GetItem(), nil
+}
+
+// get all tag names of specific space name
+func (client *metaClient) GetTags(spaceName string) ([]string, error) {
+	req := meta.NewListTagsReq()
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		return nil, err
+	}
+	req.SetSpaceID(spaceItem.GetSpaceID())
+
+	resp, err := client.meta.ListTags(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.ListTags(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var tags []string
+	for _, name := range resp.GetTags() {
+		tags = append(tags, string(name.GetTagName()))
+	}
+	return tags, nil
+}
+
+// get schema of specifc tag
+func (client *metaClient) GetTag(spaceName string, tag string) (*meta.Schema, error) {
+	req := meta.NewGetTagReq()
+
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		return nil, err
+	}
+	req.SetSpaceID(spaceItem.GetSpaceID())
+	req.SetTagName([]byte(tag))
+	req.SetVersion(client.latestSchemaVersion)
+	resp, err := client.meta.GetTag(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.GetTag(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return resp.GetSchema(), nil
+}
+
+// get all edge names of specific space name
+func (client *metaClient) GetEdges(spaceName string) ([]string, error) {
+	req := meta.NewListEdgesReq()
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		return nil, err
+	}
+	req.SetSpaceID(spaceItem.GetSpaceID())
+
+	resp, err := client.meta.ListEdges(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.ListEdges(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var edges []string
+	for _, name := range resp.GetEdges() {
+		edges = append(edges, string(name.GetEdgeName()))
+	}
+	return edges, nil
+}
+
+// get schema of specifc tag
+func (client *metaClient) GetEdge(spaceName string, edge string) (*meta.Schema, error) {
+	req := meta.NewGetEdgeReq()
+
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		return nil, err
+	}
+	req.SetSpaceID(spaceItem.GetSpaceID())
+	req.SetEdgeName([]byte(edge))
+	req.SetVersion(client.latestSchemaVersion)
+
+	resp, err := client.meta.GetEdge(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.GetEdge(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return resp.GetSchema(), nil
+}
+
+// get the allocation of all parts.
+func (client *metaClient) GetPartsAlloc(spaceName string) (map[nebula.PartitionID][]*nebula.HostAddr, error) {
+	req := meta.NewGetPartsAllocReq()
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		return nil, err
+	}
+	req.SetSpaceID(spaceItem.GetSpaceID())
+	resp, err := client.meta.GetPartsAlloc(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.GetPartsAlloc(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.GetCode() == nebula.ErrorCode_SUCCEEDED {
+		return resp.GetParts(), nil
+	} else {
+		return nil, fmt.Errorf("GetPartsAlloc failed, code:%s", resp.GetCode())
+	}
+}
+
+// get the leader host of all parts
+func (client *metaClient) GetPartsLeader(spaceName string) (map[nebula.PartitionID]*nebula.HostAddr, error) {
+	req := meta.NewListHostsReq()
+	req.SetType(meta.ListHostType_ALLOC)
+
+	resp, err := client.meta.ListHosts(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.ListHosts(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if resp.GetCode() == nebula.ErrorCode_SUCCEEDED {
+		hostItems := resp.GetHosts()
+		var partLeaders map[nebula.PartitionID]*nebula.HostAddr
+		for _, hostItem := range hostItems {
+			parts := hostItem.GetLeaderParts()[spaceName]
+			for _, part := range parts {
+				partLeaders[part] = hostItem.GetHostAddr()
+			}
+		}
+		return partLeaders, nil
+	} else {
+		return nil, fmt.Errorf("GetPartsLeader failed, code:%s", resp.GetCode())
+	}
+}
+
+// list all storaged hosts
+func (client *metaClient) ListStorageHosts() ([]*nebula.HostAddr, error) {
+	req := meta.NewListHostsReq()
+	req.SetType(meta.ListHostType_STORAGE)
+
+	resp, err := client.meta.ListHosts(req)
+	if err != nil {
+		return nil, err
+	}
+	// fresh metaClient with real leader and re-execute the request
+	if resp.GetCode() == nebula.ErrorCode_E_LEADER_CHANGED {
+		client.freshClient(resp.GetLeader())
+		resp, err = client.meta.ListHosts(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if resp.GetCode() == nebula.ErrorCode_SUCCEEDED {
+		var hosts []*nebula.HostAddr
+		for _, host := range resp.GetHosts() {
+			hosts = append(hosts, host.GetHostAddr())
+		}
+		return hosts, nil
+	} else {
+		return nil, fmt.Errorf("ListStorageHosts failed, code:%s", resp.GetCode())
+	}
+
+}
+
+// fresh the metaClient with meta leader host
+func (client *metaClient) freshClient(leader *nebula.HostAddr) {
+	client.close()
+	ip := leader.Host
+	port := leader.Port
+	client.doOpen(ip, int(port))
+}
+
+// close the metaClient
+func (client *metaClient) close() {
+	client.meta.Close()
+}

--- a/meta_client.go
+++ b/meta_client.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2020 vesoft inc. All rights reserved.
+ * Copyright (c) 2023 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License.
  *

--- a/meta_client_test.go
+++ b/meta_client_test.go
@@ -1,0 +1,206 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package nebula_go
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var ip = "127.0.0.1"
+var metaPort = 9559
+var graphPort = 9669
+var metaAddress = HostAddress{ip, metaPort}
+var client = NewMetaClient(metaAddress, 2*time.Second)
+
+var spaceName = "test_meta"
+
+func init() {
+	openClient()
+	mockSchema()
+}
+
+func openClient() {
+	err := client.Open()
+	if err != nil {
+		log.Fatal(fmt.Sprintf("open meta client failed, host:%s, port:%d, %s", ip, metaPort, err.Error()))
+	}
+}
+
+func mockSchema() {
+	// create schema in NebulaGraph
+	hostAddress := HostAddress{Host: ip, Port: graphPort}
+	hostList := []HostAddress{hostAddress}
+	// Create configs for connection pool using default values
+	testPoolConfig := GetDefaultConf()
+
+	// Initialize connection pool
+	pool, err := NewConnectionPool(hostList, testPoolConfig, DefaultLogger{})
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Fail to initialize the connection pool, host: %s, port: %d, %s", ip, graphPort, err.Error()))
+	}
+	// Close all connections in the pool
+	defer pool.Close()
+
+	username := "root"
+	password := "nebula"
+	// Create session
+	session, err := pool.GetSession(username, password)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Fail to create a new session from connection pool, username: %s, password: %s, %s",
+			username, password, err.Error()))
+	}
+	// Release session and return connection back to connection pool
+	defer session.Release()
+	resultSet, err := session.Execute("CREATE SPACE IF NOT EXISTS test_meta(vid_type=int64, partition_num=10);" +
+		"USE test_meta; CREATE TAG IF NOT EXISTS person(name string, age int32);" +
+		"CREATE TAG IF NOT EXISTS player(name string, team string);" +
+		"CREATE EDGE IF NOT EXISTS friend(degree int64)")
+	if err != nil {
+		log.Fatal("create schema error.", err.Error())
+
+	}
+	if !resultSet.IsSucceed() {
+		log.Fatal(fmt.Sprintf("create schema failed, message:%s", resultSet.GetErrorMsg()))
+	}
+}
+
+func teardown() {
+	if client != nil {
+		client.Close()
+	}
+}
+
+func TestMetaClientOpen(t *testing.T) {
+	address := HostAddress{Host: ip, Port: metaPort}
+	localMetaClient := NewMetaClient(address, 2*time.Second)
+	err := localMetaClient.Open()
+	defer localMetaClient.Close()
+	if err != nil {
+		t.Errorf(fmt.Sprintf("expect open metaClient success, but failed, messgae:%s", err.Error()))
+	}
+	// test ipv6
+	addrIpv6 := "::1"
+	address = HostAddress{Host: addrIpv6, Port: metaPort}
+	ipv6MetaClient := NewMetaClient(address, 2*time.Second)
+	err = ipv6MetaClient.Open()
+	defer ipv6MetaClient.Close()
+	if err != nil {
+		t.Errorf(fmt.Sprintf("expect open metaClient success with ipv6 host, but failed, message:%s", err.Error()))
+	}
+
+	// test wrong host
+	address = HostAddress{Host: "1.1.1.1", Port: 9559}
+	wrongMetaClient := NewMetaClient(address, 2*time.Second)
+	err = wrongMetaClient.Open()
+	defer wrongMetaClient.Close()
+	if err != nil {
+		assert.EqualError(t, err, "failed to open transport, error: dial tcp 1.1.1.1:9559: i/o timeout")
+	}
+}
+
+func TestGetSpaces(t *testing.T) {
+	names, err := client.GetSpaces()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, names, spaceName, "space names must contains %s, but not found.", spaceName)
+}
+
+func TestGetSpace(t *testing.T) {
+	spaceItem, err := client.GetSpace(spaceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, string(spaceItem.GetProperties().GetSpaceName()), spaceName)
+}
+
+func TestGetTags(t *testing.T) {
+	tags, err := client.GetTags(spaceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(tags), 2)
+}
+
+func TestGetTag(t *testing.T) {
+	tagName := "person"
+	schema, err := client.GetTag(spaceName, tagName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(schema.GetColumns()), 2)
+}
+
+func TestGetEdges(t *testing.T) {
+	edges, err := client.GetEdges(spaceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(edges), 1)
+}
+
+func TestGetEdge(t *testing.T) {
+	edgeName := "friend"
+	schema, err := client.GetEdge(spaceName, edgeName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(schema.GetColumns()), 1)
+}
+
+func TestGetPartsAlloc(t *testing.T) {
+	partsAllocMap, err := client.GetPartsAlloc(spaceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(partsAllocMap), 10, fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partsAllocMap)))
+}
+
+func TestGetPartLeaders(t *testing.T) {
+	partToHostMap, err := client.GetPartsLeader(spaceName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(partToHostMap), 10, fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partToHostMap)))
+}
+
+func TestGetHosts(t *testing.T) {
+	hostList, err := client.ListStorageHosts()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(hostList), 3, fmt.Sprintf("storaged hosts num expect 3, but got %d", len(hostList)))
+}
+
+func TestMetaClientExecuteAfterClose(t *testing.T) {
+	address := HostAddress{Host: ip, Port: metaPort}
+	localMetaClient := NewMetaClient(address, 2*time.Second)
+	err := localMetaClient.Open()
+	defer localMetaClient.Close()
+	if err != nil {
+		t.Errorf(fmt.Sprintf("expect open metaClient success, but failed, messgae:%s", err.Error()))
+	}
+	localMetaClient.Close()
+	names, err := localMetaClient.GetSpaces()
+	if err != nil {
+		assert.EqualError(t, err, "Connection not open")
+	} else {
+		fmt.Printf(names[0])
+		t.Errorf("expect error when getSpaces after client has been closed.")
+	}
+}
+
+func TestMain(m *testing.M) {
+	retCode := m.Run()
+	teardown()
+	os.Exit(retCode)
+}

--- a/meta_client_test.go
+++ b/meta_client_test.go
@@ -71,7 +71,6 @@ func mockSchema() {
 		"CREATE EDGE IF NOT EXISTS friend(degree int64)")
 	if err != nil {
 		log.Fatal("create schema error.", err.Error())
-
 	}
 	if !resultSet.IsSucceed() {
 		log.Fatal(fmt.Sprintf("create schema failed, message:%s", resultSet.GetErrorMsg()))
@@ -150,7 +149,7 @@ func TestGetTags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(tags), 2)
+	assert.Equal(t, 2, len(tags))
 }
 
 func TestGetTag(t *testing.T) {
@@ -164,7 +163,7 @@ func TestGetTag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(schema.GetColumns()), 2)
+	assert.Equal(t, 2, len(schema.GetColumns()))
 }
 
 func TestGetEdges(t *testing.T) {
@@ -177,7 +176,7 @@ func TestGetEdges(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(edges), 1)
+	assert.Equal(t, 1, len(edges))
 }
 
 func TestGetEdge(t *testing.T) {
@@ -191,7 +190,7 @@ func TestGetEdge(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(schema.GetColumns()), 1)
+	assert.Equal(t, 1, len(schema.GetColumns()))
 }
 
 func TestGetPartsAlloc(t *testing.T) {
@@ -204,7 +203,7 @@ func TestGetPartsAlloc(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(partsAllocMap), 10, fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partsAllocMap)))
+	assert.Equal(t, 10, len(partsAllocMap), fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partsAllocMap)))
 }
 
 func TestGetPartLeaders(t *testing.T) {
@@ -213,11 +212,12 @@ func TestGetPartLeaders(t *testing.T) {
 	if !isOpen {
 		setup()
 	}
+	time.Sleep(10 * time.Second)
 	partToHostMap, err := client.GetPartsLeader(spaceName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(partToHostMap), 10, fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partToHostMap)))
+	assert.Equal(t, 10, len(partToHostMap), fmt.Sprintf("space test_meta has 10 parts, but got %d.", len(partToHostMap)))
 }
 
 func TestGetHosts(t *testing.T) {
@@ -230,7 +230,7 @@ func TestGetHosts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, len(hostList), 3, fmt.Sprintf("storaged hosts num expect 3, but got %d", len(hostList)))
+	assert.Equal(t, 3, len(hostList), fmt.Sprintf("storaged hosts num expect 3, but got %d", len(hostList)))
 }
 
 func TestMetaClientExecuteAfterClose(t *testing.T) {
@@ -261,6 +261,7 @@ func skipSslForMeta(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	setup()
 	retCode := m.Run()
 	teardown()
 	os.Exit(retCode)

--- a/meta_client_test.go
+++ b/meta_client_test.go
@@ -26,6 +26,7 @@ var spaceName = "test_meta"
 
 func setup() {
 	mockSchema()
+	time.Sleep(10 * time.Second)
 	openClient()
 }
 

--- a/meta_client_test.go
+++ b/meta_client_test.go
@@ -261,7 +261,9 @@ func skipSslForMeta(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	setup()
+	if os.Getenv("ssl_test") != "true" && os.Getenv("self_signed") != "true" {
+		setup()
+	}
 	retCode := m.Run()
 	teardown()
 	os.Exit(retCode)

--- a/nebula-docker-compose/docker-compose-ssl.yaml
+++ b/nebula-docker-compose/docker-compose-ssl.yaml
@@ -6,9 +6,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad0
-      - --ws_ip=metad0
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.1
+      - --ws_ip=172.28.1.1
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -24,7 +24,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad0:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.1:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -38,7 +38,8 @@ services:
       - ./data/meta0:/data/meta
       - ./logs/meta0:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -49,9 +50,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad1
-      - --ws_ip=metad1
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.2
+      - --ws_ip=172.28.1.2
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -67,7 +68,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad1:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.2:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -81,7 +82,8 @@ services:
       - ./data/meta1:/data/meta
       - ./logs/meta1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -92,9 +94,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad2
-      - --ws_ip=metad2
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.3
+      - --ws_ip=172.28.1.3
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -110,7 +112,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad2:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.3:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -124,7 +126,8 @@ services:
       - ./data/meta2:/data/meta
       - ./logs/meta2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -135,9 +138,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged0
-      - --ws_ip=storaged0
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.1
+      - --ws_ip=172.28.2.1
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -157,7 +160,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged0:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.1:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -171,7 +174,8 @@ services:
       - ./data/storage0:/data/storage
       - ./logs/storage0:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.2.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -182,9 +186,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged1
-      - --ws_ip=storaged1
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.2
+      - --ws_ip=172.28.2.2
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -204,7 +208,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged1:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.2:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -218,7 +222,8 @@ services:
       - ./data/storage1:/data/storage
       - ./logs/storage1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipve4_address: 172.28.2.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -229,9 +234,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged2
-      - --ws_ip=storaged2
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.3
+      - --ws_ip=172.28.2.3
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -251,7 +256,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged2:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.3:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -265,7 +270,8 @@ services:
       - ./data/storage2:/data/storage
       - ./logs/storage2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.2.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -276,9 +282,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd
+      - --ws_ip=172.28.3.1
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -298,7 +304,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.1:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -311,7 +317,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -322,9 +329,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd1
+      - --ws_ip=172.28.3.2
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -344,7 +351,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd1:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.2:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -357,7 +364,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -368,9 +376,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd2
+      - --ws_ip=172.28.3.3
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -385,14 +393,12 @@ services:
       - --key_path=${key_path}
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
-
-
     depends_on:
       - metad0
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd2:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.3:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -405,7 +411,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -419,7 +426,7 @@ services:
       - |
         for i in `seq 1 60`;do
           echo "Adding hosts..."
-          var=`nebula-console -addr graphd -port 3699 -u root -p nebula -enable_ssl=true -ssl_root_ca_path /secrets/test.ca.pem -ssl_cert_path /secrets/test.client.crt -ssl_private_key_path /secrets/test.client.key --ssl_insecure_skip_verify=true -e 'ADD HOSTS "storaged0":44500,"storaged1":44500,"storaged2":44500'`;
+          var=`nebula-console -addr graphd -port 3699 -u root -p nebula -enable_ssl=true -ssl_root_ca_path /secrets/test.ca.pem -ssl_cert_path /secrets/test.client.crt -ssl_private_key_path /secrets/test.client.key --ssl_insecure_skip_verify=true -e 'ADD HOSTS "172.28.2.1":44500,"172.28.2.2":44500,"172.28.2.3":44500'`;
           if [[ $$? == 0 ]];then
             echo "Hosts added successfully"
             break;
@@ -436,3 +443,7 @@ services:
 
 networks:
   nebula-net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16

--- a/nebula-docker-compose/docker-compose-ssl.yaml
+++ b/nebula-docker-compose/docker-compose-ssl.yaml
@@ -223,7 +223,7 @@ services:
       - ./logs/storage1:/logs
     networks:
       nebula-net:
-        ipve4_address: 172.28.2.2
+        ipv4_address: 172.28.2.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE

--- a/nebula-docker-compose/docker-compose-ssl.yaml
+++ b/nebula-docker-compose/docker-compose-ssl.yaml
@@ -30,7 +30,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9559:45500"
       - 11000
       - 11002
     volumes:
@@ -73,7 +73,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9560:45500"
       - 11000
       - 11002
     volumes:
@@ -116,7 +116,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9561:45500"
       - 11000
       - 11002
     volumes:
@@ -163,7 +163,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44500:44500"
       - 12000
       - 12002
     volumes:
@@ -210,7 +210,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44501:44500"
       - 12000
       - 12002
     volumes:
@@ -257,7 +257,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44502:44500"
       - 12000
       - 12002
     volumes:

--- a/nebula-docker-compose/docker-compose.yaml
+++ b/nebula-docker-compose/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9559:45500"
       - 11000
       - 11002
     volumes:
@@ -73,7 +73,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9560:45500"
       - 11000
       - 11002
     volumes:
@@ -116,7 +116,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 45500
+      - "9561:45500"
       - 11000
       - 11002
     volumes:
@@ -163,7 +163,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44500:44500"
       - 12000
       - 12002
     volumes:
@@ -210,7 +210,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44501:44500"
       - 12000
       - 12002
     volumes:
@@ -257,7 +257,7 @@ services:
       retries: 3
       start_period: 20s
     ports:
-      - 44500
+      - "44502:44500"
       - 12000
       - 12002
     volumes:

--- a/nebula-docker-compose/docker-compose.yaml
+++ b/nebula-docker-compose/docker-compose.yaml
@@ -6,9 +6,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad0
-      - --ws_ip=metad0
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.1
+      - --ws_ip=172.28.1.1
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -24,7 +24,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad0:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.1:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -38,7 +38,8 @@ services:
       - ./data/meta0:/data/meta
       - ./logs/meta0:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -49,9 +50,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad1
-      - --ws_ip=metad1
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.2
+      - --ws_ip=172.28.1.2
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -67,7 +68,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad1:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.2:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -81,7 +82,8 @@ services:
       - ./data/meta1:/data/meta
       - ./logs/meta1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -92,9 +94,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=metad2
-      - --ws_ip=metad2
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.1.3
+      - --ws_ip=172.28.1.3
       - --port=45500
       - --ws_http_port=11000
       - --data_path=/data/meta
@@ -110,7 +112,7 @@ services:
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://metad2:11000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.1.3:11000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -124,7 +126,8 @@ services:
       - ./data/meta2:/data/meta
       - ./logs/meta2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.1.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -135,9 +138,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged0
-      - --ws_ip=storaged0
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.1
+      - --ws_ip=172.28.2.1
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -157,7 +160,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged0:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.1:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -171,7 +174,8 @@ services:
       - ./data/storage0:/data/storage
       - ./logs/storage0:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.2.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -182,9 +186,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged1
-      - --ws_ip=storaged1
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.2
+      - --ws_ip=172.28.2.2
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -204,7 +208,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged1:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.2:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -218,7 +222,8 @@ services:
       - ./data/storage1:/data/storage
       - ./logs/storage1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.2.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -229,9 +234,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
-      - --local_ip=storaged2
-      - --ws_ip=storaged2
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
+      - --local_ip=172.28.2.3
+      - --ws_ip=172.28.2.3
       - --port=44500
       - --ws_http_port=12000
       - --data_path=/data/storage
@@ -251,7 +256,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://storaged2:12000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.2.3:12000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -265,7 +270,8 @@ services:
       - ./data/storage2:/data/storage
       - ./logs/storage2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.2.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -276,9 +282,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd
+      - --ws_ip=172.28.3.1
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -299,7 +305,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.1:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -312,7 +318,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.1
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -323,9 +330,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd1
+      - --ws_ip=172.28.3.2
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -346,7 +353,7 @@ services:
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd1:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.2:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -359,7 +366,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph1:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.2
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -370,9 +378,9 @@ services:
       USER: root
       TZ:   "${TZ}"
     command:
-      - --meta_server_addrs=metad0:45500,metad1:45500,metad2:45500
+      - --meta_server_addrs=172.28.1.1:45500,172.28.1.2:45500,172.28.1.3:45500
       - --port=3699
-      - --ws_ip=graphd2
+      - --ws_ip=172.28.3.3
       - --ws_http_port=13000
       - --log_dir=/logs
       - --v=0
@@ -388,14 +396,12 @@ services:
       - --key_path=${key_path}
       - --enable_ssl=${enable_ssl}
       - --password_path=${password_path}
-
-
     depends_on:
       - metad0
       - metad1
       - metad2
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://graphd2:13000/status"]
+      test: ["CMD", "curl", "-sf", "http://172.28.3.3:13000/status"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -408,7 +414,8 @@ services:
       - ./secrets:/secrets
       - ./logs/graph2:/logs
     networks:
-      - nebula-net
+      nebula-net:
+        ipv4_address: 172.28.3.3
     restart: on-failure
     cap_add:
       - SYS_PTRACE
@@ -421,7 +428,7 @@ services:
       - -c
       - |
         for i in `seq 1 60`;do
-          var=`nebula-console -addr graphd -port 3699 -u root -p nebula -e 'ADD HOSTS "storaged0":44500,"storaged1":44500,"storaged2":44500'`;
+          var=`nebula-console -addr graphd -port 3699 -u root -p nebula -e 'ADD HOSTS "172.28.2.1":44500,"172.28.2.2":44500,"172.28.2.3":44500'`;
           if [[ $$? == 0 ]];then
             break;
           fi;
@@ -435,3 +442,7 @@ services:
 
 networks:
   nebula-net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16


### PR DESCRIPTION
add meta client to support the storage client.
* there's requirement for cloud to support exporting NebulaGraph's data, need to provide storage client scan interface in go sdk. 
* When scan data from nebula storaged server, the client need all storaged hosts and some schema informations, such as tag/edge schema, space part number.

related issue:https://github.com/vesoft-inc/nebula-go/issues/276