### PR TITLE
hotfix: fix the field index conflict inside the method Scan of ResultSet

### DIFF
--- a/result_set.go
+++ b/result_set.go
@@ -336,31 +336,31 @@ func (res ResultSet) Scan(v interface{}) error {
 
 // Scan scans the rows into the given value.
 func (res ResultSet) scanRow(row *nebula.Row, colNames []string, t reflect.Type) (reflect.Value, error) {
-	rowValues := row.GetValues()
+	rowVals := row.GetValues()
 
 	val := reflect.New(t).Elem()
 
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
+	for fIdx := 0; fIdx < t.NumField(); fIdx++ {
+		f := t.Field(fIdx)
 		tag := f.Tag.Get("nebula")
 
 		if tag == "" {
 			continue
 		}
 
-		i := IndexOf(colNames, tag)
-		if i == -1 {
+		cIdx := IndexOf(colNames, tag)
+		if cIdx == -1 {
 			// It is possible that the tag is not in the result set
 			continue
 		}
 
-		rowVal := rowValues[i]
+		rowVal := rowVals[cIdx]
 
 		switch f.Type.Kind() {
 		case reflect.Int64:
-			val.Field(i).SetInt(rowVal.GetIVal())
+			val.Field(fIdx).SetInt(rowVal.GetIVal())
 		case reflect.String:
-			val.Field(i).SetString(string(rowVal.GetSVal()))
+			val.Field(fIdx).SetString(string(rowVal.GetSVal()))
 		default:
 			return val, errors.New("scan: not support type")
 		}


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

This is hotfix because there is a variable overriding of the `i` :)

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


