### PR TITLE
Add GetLatencyInMs for ResultSet

### DIFF
--- a/result_set.go
+++ b/result_set.go
@@ -434,6 +434,10 @@ func (res ResultSet) GetLatency() int64 {
 	return res.resp.LatencyInUs
 }
 
+func (res ResultSet) GetLatencyInMs() int64 {
+	return res.resp.LatencyInUs / 1000
+}
+
 func (res ResultSet) GetSpaceName() string {
 	if res.resp.SpaceName == nil {
 		return ""

--- a/result_set_test.go
+++ b/result_set_test.go
@@ -631,6 +631,7 @@ func TestResultSet(t *testing.T) {
 
 	assert.Equal(t, ErrorCode_E_STATEMENT_EMPTY, resultSetWithNil.GetErrorCode())
 	assert.Equal(t, int64(1000), resultSetWithNil.GetLatency())
+	assert.Equal(t, int64(1), resultSetWithNil.GetLatencyInMs())
 	assert.Equal(t, "", resultSetWithNil.GetErrorMsg())
 	assert.Equal(t, "", resultSetWithNil.GetSpaceName())
 	assert.Equal(t, "", resultSetWithNil.GetComment())
@@ -675,6 +676,7 @@ func TestResultSet(t *testing.T) {
 	}
 	assert.Equal(t, ErrorCode_SUCCEEDED, resultSet.GetErrorCode())
 	assert.Equal(t, int64(1000), resultSet.GetLatency())
+	assert.Equal(t, int64(1), resultSet.GetLatencyInMs())
 	assert.Equal(t, "test_err_msg", resultSet.GetErrorMsg())
 	assert.Equal(t, "test_space", resultSet.GetSpaceName())
 	assert.Equal(t, "test_comment", resultSet.GetComment())


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:


Every time I want to log the latency, I always need to transform it into the ms unit.
I think the ms is more useful for most users.

```go
// before
slog.Info("Executed query", "statement", statement, "latency_in_ms", rs.GetLatency()/1000)
// after
slog.Info("Executed query", "statement", statement, "latency", rs.GetLatencyInMs())
```

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


