### PR TITLE
Connection pool: put conn to idle queue if auth responded with unsuccessful code

### DIFF
--- a/session.go
+++ b/session.go
@@ -217,7 +217,7 @@ func (session *Session) CreateSpace(conf SpaceConf) (*ResultSet, error) {
 		conf.VidType = "FIXED_STRING(8)"
 	}
 
-	q := ""
+	var q string
 	if conf.IgnoreIfExists {
 		q = fmt.Sprintf(
 			"CREATE SPACE IF NOT EXISTS %s (partition_num = %d, replica_factor = %d, vid_type = %s)",

--- a/session.go
+++ b/session.go
@@ -49,7 +49,6 @@ func (session *Session) executeWithReconnect(f func() (interface{}, error)) (int
 	}
 	// Execute with the new connection
 	return f()
-
 }
 
 // ExecuteWithParameter returns the result of the given query as a ResultSet
@@ -81,7 +80,6 @@ func (session *Session) ExecuteWithParameter(stmt string, params map[string]inte
 		return nil, err
 	}
 	return resp.(*ResultSet), err
-
 }
 
 // Execute returns the result of the given query as a ResultSet
@@ -264,7 +262,7 @@ func (session *Session) reConnect() error {
 		return err
 	}
 
-	session.connPool.releaseAndBack(session.connection, false)
+	session.connPool.deactivate(session.connection, false, false)
 	session.connection = newConnection
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
[#334](https://github.com/vesoft-inc/nebula-go/issues/334)

#### Description:
As in [connection_pool.go](https://github.com/vesoft-inc/nebula-go/blob/master/connection_pool.go#L111), ConnectionPool deactivates the current connection by putting it to idle queue if authentication failed (i.e. conn.authenticate returns an non-nil error). However, if authentication returns an nil error but with an unsuccessful ErrorCode, the connection won't be deactivated. Therefore, consecutive unsuccessful responses of authentication could eventually use up the connection pool, causing no new connections is able to be created.

## How do you solve it?
I treat both authentication failure scenarios with the same handling, that the connection is put back to idle queue if failed.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


