### PR TITLE
Expose query timeout error code to the result_set

### DIFF
--- a/result_set.go
+++ b/result_set.go
@@ -94,6 +94,7 @@ const (
 	ErrorCode_E_BAD_PERMISSION        ErrorCode = ErrorCode(nebula.ErrorCode_E_BAD_PERMISSION)
 	ErrorCode_E_SEMANTIC_ERROR        ErrorCode = ErrorCode(nebula.ErrorCode_E_SEMANTIC_ERROR)
 	ErrorCode_E_PARTIAL_SUCCEEDED     ErrorCode = ErrorCode(nebula.ErrorCode_E_PARTIAL_SUCCEEDED)
+	ErrorCode_E_QUERY_TIMEDOUT        ErrorCode = ErrorCode(nebula.ErrorCode_E_QUERY_TIMEDOUT)
 )
 
 func GenResultSet(resp *graph.ExecutionResponse) (*ResultSet, error) {
@@ -484,6 +485,10 @@ func (res ResultSet) IsSucceed() bool {
 
 func (res ResultSet) IsPartialSucceed() bool {
 	return res.GetErrorCode() == ErrorCode_E_PARTIAL_SUCCEEDED
+}
+
+func (res ResultSet) IsQueryTimeout() bool {
+	return res.GetErrorCode() == ErrorCode_E_QUERY_TIMEDOUT
 }
 
 func (res ResultSet) hasColName(colName string) bool {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
User is relying on `GetErrorCode` in the result_set.go to retrieve the error code. As a upgrade process, we do not want our business user to change their application code. Therefore, we expose the `ErrorCode_E_QUERY_TIMEDOUT` from `ttypes` to `result_set`.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


