### PR TITLE
fix decimal type

### DIFF
--- a/internal/decode/resultTable_helper.go
+++ b/internal/decode/resultTable_helper.go
@@ -184,7 +184,7 @@ func (c *vectorDecoder) decodeDecimalValue() decodeFlatFn {
 			chunk := v.NestedVectors[chunkIndex]
 			data := chunk.VectorData[chunkOffset : chunkOffset+strLen]
 			offset := dctx.timezoneOffset
-			decodeBasicValue(data, value, types.ColumnTypeString, offset)
+			decodeBasicValue(data, value, types.ColumnTypeDecimal, offset)
 		}
 		return nil
 	}

--- a/internal/decode/resultTable_helper_test.go
+++ b/internal/decode/resultTable_helper_test.go
@@ -1,0 +1,39 @@
+package decode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vesoft-inc/nebula-go/v5/internal/generated_code/v5.0.0/proto/vector"
+	"github.com/vesoft-inc/nebula-go/v5/pkg/types"
+)
+
+func TestDecodeDecimalValue_LongDecimalKeepsDecimalType(t *testing.T) {
+	decimal := "1234567890123.456789"
+	header := make([]byte, 16)
+	order.PutUint32(header[:4], uint32(len(decimal)))
+	order.PutUint32(header[8:12], 0)
+	order.PutUint32(header[12:16], 0)
+
+	nested := &vector.NestedVector{
+		VectorData: header,
+		NestedVectors: []*vector.NestedVector{
+			{VectorData: []byte(decimal)},
+		},
+	}
+
+	value := &NebulaValue{}
+	err := defaultDecoder.(*vectorDecoder).decodeDecimalValue()(
+		&decodeContext{},
+		value,
+		nested,
+		0,
+		&columnTypeSchemaBasic{typ: types.ColumnTypeDecimal},
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, types.ValueTypeDecimal, value.GetType())
+	decoded, err := value.AsDecimal()
+	require.NoError(t, err)
+	require.Equal(t, decimal, decoded.String())
+}


### PR DESCRIPTION
Fix flat vector decoding for long decimal values in internal/decode.

  Previously, decodeDecimalValue() handled inline decimals correctly but decoded chunk-backed long decimals as string, which caused type inconsistency at runtime: short decimals became
  NebulaDecimal, while long decimals became NebulaString. This could break callers relying on GetType(), AsDecimal(), or stable decimal handling.

  This change updates the long-decimal path to decode as types.ColumnTypeDecimal, so both short and long decimals consistently produce NebulaDecimal. It also adds a regression test covering the
  chunk-backed decimal case to prevent this from slipping again.