### PR TITLE
fix empty batch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.out
 **/certs*/*srl
 **/logs
 *.out
+.DS_Store

--- a/internal/decode/resultTable.go
+++ b/internal/decode/resultTable.go
@@ -3,9 +3,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -265,27 +265,26 @@ func (rt *ResultTable) constructGraphsSchema() graphsSchema {
 }
 
 func (rt *ResultTable) getCurrentBatch() error {
-	if rt.currentBatch == nil {
-		if len(rt.batches) == 0 {
-			return io.EOF
-		} else {
-			rt.currentBatch = rt.batches[0]
-		}
-	}
-	if rt.currentBatchRowIndex >= rt.currentBatch.numRecords() {
-		rt.batchIndex++
-		rt.currentBatchRowIndex = 0
-		if rt.batchIndex >= uint64(rt.numBatches) {
+	for {
+		if len(rt.batches) == 0 || rt.batchIndex >= uint64(rt.numBatches) {
 			return io.EOF
 		}
+		if rt.currentBatch == nil {
+			rt.currentBatch = rt.batches[rt.batchIndex]
+		}
+		if rt.currentBatchRowIndex < rt.currentBatch.numRecords() {
+			return nil
+		}
+
 		batch, ok := rt.currentBatch.(*batch)
 		if ok {
 			batch.vectors = nil
 		}
 
-		rt.currentBatch = rt.batches[rt.batchIndex]
+		rt.batchIndex++
+		rt.currentBatchRowIndex = 0
+		rt.currentBatch = nil
 	}
-	return nil
 }
 
 func (rt *ResultTable) Scan(values []types.Value) error {

--- a/internal/decode/resultTable_test.go
+++ b/internal/decode/resultTable_test.go
@@ -3,9 +3,9 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
-//     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -90,4 +90,31 @@ func TestTable(t *testing.T) {
 			assert.NoError(t, err, tc.name)
 		}
 	}
+}
+
+func TestTableSkipsEmptyBatches(t *testing.T) {
+	batches := []batcher{
+		&dummpBatch{name: "empty-head", rows: 0},
+		&dummpBatch{name: "first-data", rows: 1},
+		&dummpBatch{name: "empty-middle", rows: 0},
+		&dummpBatch{name: "second-data", rows: 2},
+		&dummpBatch{name: "empty-tail", rows: 0},
+	}
+
+	tbl := &ResultTable{
+		batches:     batches,
+		numBatches:  len(batches),
+		columnNames: []string{"c1"},
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err := tbl.Next()
+		assert.NoError(t, err)
+	}
+
+	assert.Equal(t, uint64(3), tbl.batchIndex)
+	assert.Equal(t, uint32(2), tbl.currentBatchRowIndex)
+
+	_, err := tbl.Next()
+	assert.ErrorIs(t, err, io.EOF)
 }


### PR DESCRIPTION
## Summary
This PR fixes result-table iteration when the response contains empty batches.

Previously, getCurrentBatch only advanced one batch at a time. If the current batch was exhausted and the next batch was empty, Next/Scan could return io.EOF too early even when later batches still contained rows.

This change updates the batch-selection logic to keep advancing until it finds a non-empty batch or reaches the real end of the result table.

## Changes
- update internal/decode/resultTable.go to skip consecutive empty batches during iteration
- keep the state transition logic explicit by resetting currentBatch and reloading it in the next loop iteration
- add regression coverage for leading, middle, and trailing empty batches
- ignore .DS_Store in .gitignore

## Testing
- go test ./internal/decode/...